### PR TITLE
[BUGFIX] Honor colspan argument in BE grids

### DIFF
--- a/Classes/Backend/BackendLayout.php
+++ b/Classes/Backend/BackendLayout.php
@@ -125,7 +125,7 @@ class Tx_Fluidpages_Backend_BackendLayout implements t3lib_Singleton {
 				}
 				array_push($colPosList, $columns[$key]['colPos']);
 				array_push($items, array($columns[$key]['name'], $columns[$key]['colPos'], NULL));
-				$colCount++;
+				$colCount += $column['colspan'] ? $column['colspan'] : 1;
 			}
 			$config['colCount'] = max($config['colCount'], $colCount);
 			$config['rowCount']++;


### PR DESCRIPTION
As discussed in the forum. Grids in the backend now behave like backend layouts regarding colspan.
