### PR TITLE
[TASK] Introduce new TypoScript location for collections (safe merge)

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -44,7 +44,10 @@ class Tx_Fluidpages_Service_ConfigurationService extends Tx_Flux_Service_Configu
 	 * @api
 	 */
 	public function getPageConfiguration($extensionName = NULL) {
-		return $this->getTypoScriptSubConfiguration($extensionName, 'page');
+		$newLocation = $this->getTypoScriptSubConfiguration($extensionName, 'collections', array(), 'fluidpages');
+		$oldLocation = $this->getTypoScriptSubConfiguration($extensionName, 'page', array(), 'fed');
+		$merged = t3lib_div::array_merge_recursive_overrule($oldLocation, $newLocation);
+		return $merged;
 	}
 
 }


### PR DESCRIPTION
This enables the new location plugin.tx_fluidpages.collections.extensionKey to be used, finally separating FluidPages from FED. For backwards compatibility the old location is merged but given lower priority than the new location.

Pre-tested; relies on very recent Flux PR to enable the fourth parameter for getTypoScriptSubConfiguration.
