### PR TITLE
[TASK] Redirect errors, don't forward

### DIFF
--- a/Classes/Controller/PageController.php
+++ b/Classes/Controller/PageController.php
@@ -63,12 +63,8 @@ class Tx_Fluidpages_Controller_PageController extends Tx_Fluidpages_Controller_A
 		} catch (Exception $error) {
 			$this->debugService->debug($error);
 			$code = $error->getCode();
-			if (1364498093 !== $code && 1364498223 !== $code) {
-				$this->request->setErrors(array('page' => $error));
-				$this->request->setControllerActionName('error');
-				$this->forward('error');
-			}
-			$content = $this->view->render();
+			$errors = array('page' => $error->getCode());
+			$this->redirect('error', $this->request->getControllerName(), $this->request->getControllerExtensionName(), $errors);
 		}
 		return $content;
 	}


### PR DESCRIPTION
This will 1) prevent possible fatal errors when error views are not configured or handled and 2) allow future improvements to take advantage of redirection to other pages to display errors, for example with a funnel to report the error.
