### PR TITLE
Fix page template configuration *second try*

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -88,86 +88,71 @@ class Tx_Fluidpages_Service_PageService implements t3lib_Singleton {
 	 * @api
 	 */
 	public function getPageTemplateConfiguration($pageUid) {
+		$pageUid = intval($pageUid);
+		$workspaceId = intval($GLOBALS['BE_USER']->workspace);
+		$cacheKey = 'page_uid' . $pageUid . '_wsid' . $workspaceId;
+		if (1 > $pageUid) {
+			return NULL;
+		}
+		if (TRUE === isset(self::$cache[$cacheKey])) {
+			return self::$cache[$cacheKey];
+		}
+		$page = $this->getPage($pageUid);
+		// if page has a controller action
+		if (strpos($page['tx_fed_page_controller_action'], '->')) {
+			return $page;
+		}
+		// if no controller action was found loop through rootline
+		do {
+			$page = $this->getPageParent($page);
+		} while (FALSE !== $page && FALSE === strpos($page['tx_fed_page_controller_action_sub'], '->'));
+		if (FALSE === $page) {
+			self::$cache[$cacheKey] = NULL;
+			return NULL;
+		}
+		$page['tx_fed_page_controller_action'] = $page['tx_fed_page_controller_action_sub'];
+		if (TRUE === empty($page['tx_fed_page_controller_action'])) {
+			$page = NULL;
+		}
+		self::$cache[$cacheKey] = $page;
+		return $page;
 
-        $pageUid  = (int)$pageUid;
-        $wsId     = (int)$GLOBALS['BE_USER']->workspace;
-        $cacheKey = 'page_uid' . $pageUid . '_wsid' . $wsId;
+	}
 
-        if ( $pageUid < 1 ) {
-            return NULL;
-        }
+	/**
+	 * Return the original or workspace page depending on workspace-mode
+	 *
+	 * @param integer $pageUid
+	 * @return array|boolean
+	 */
+	protected function getPage($pageUid) {
+		$table = 'pages';
+		$wsId = intval($GLOBALS['BE_USER']->workspace);
+		$pageUid = intval($pageUid);
+		if (1 > $pageUid) {
+			return FALSE;
+		}
+		// check if active workspace is available
+		$page = t3lib_BEfunc::getWorkspaceVersionOfRecord($wsId, $table, $pageUid);
+		if (FALSE === $page) {
+			// no workspace available ... use original one
+			$page = t3lib_BEfunc::getRecord($table, $pageUid, '*');
+		}
+		return $page;
+	}
 
-        if (TRUE === isset(self::$cache[$cacheKey])) {
-            return self::$cache[$cacheKey];
-        }
-
-        $page = $this->getPage($pageUid);
-
-        // if page has a controller action
-        if (strpos($page['tx_fed_page_controller_action'], '->')) {
-            return $page;
-        }
-
-        // if no controller action was found loop through rootline
-        do {
-            $page = $this->getPageParent($page);
-        } while ($page && !strpos($page['tx_fed_page_controller_action_sub'], '->'));
-
-        if ( !$page ) {
-            self::$cache[$cacheKey] = NULL;
-            return NULL;
-        }
-
-        $page['tx_fed_page_controller_action'] = $page['tx_fed_page_controller_action_sub'];
-
-        if (TRUE === empty($page['tx_fed_page_controller_action'])) {
-            $page = NULL;
-        }
-
-        self::$cache[$cacheKey] = $page;
-
-        return $page;
-
-    }
-
-    /**
-     * Return the original or workspace page depending on workspace-mode
-     *
-     * @param integer $pageUid
-     * @return array|bool
-     */
-    protected function getPage($pageUid) {
-
-        $table   = 'pages';
-        $wsId    = (int)$GLOBALS['BE_USER']->workspace;
-        $pageUid = (int)$pageUid;
-
-        if ( $pageUid === 0 ) {
-            return FALSE;
-        }
-
-        // check if active workspace is available
-        if ( !$page = \TYPO3\CMS\Backend\Utility\BackendUtility::getWorkspaceVersionOfRecord($wsId, $table, $pageUid) ) {
-            // no workspace available ... use original one
-            $pgRepo = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
-            $page   = $pgRepo->getPage($pageUid);
-        }
-
-        return $page;
-    }
-
-    /**
-     * Return parent page array
-     *
-     * @param array $page
-     * @return array|bool
-     */
-    protected function getPageParent($page) {
-        // try to get the original page
-        $live  = \TYPO3\CMS\Backend\Utility\BackendUtility::getLiveVersionOfRecord('pages', (int)$page['uid']);
-        $live  = $live === NULL ? $page : $live;
-        return $this->getPage( (int)$live['pid'] );
-    }
+	/**
+	 * Return parent page array
+	 *
+	 * @param array $page
+	 * @return array|boolean
+	 */
+	protected function getPageParent($page) {
+		// try to get the original page
+		$live = t3lib_BEfunc::getLiveVersionIdOfRecord('pages', intval($page['uid']));
+		$live = ($live === NULL ? $page : $live);
+		return $this->getPage($live['pid']);
+	}
 
 	/**
 	 * Gets the workspace parent for a given page
@@ -217,7 +202,6 @@ class Tx_Fluidpages_Service_PageService implements t3lib_Singleton {
 		} elseif ($page['t3ver_state'] == 4) {
 			// page has moved. get placeholder for new position
 			$page = t3lib_BEfunc::getRecordRaw('pages', $where = sprintf('t3ver_move_id=%d AND t3ver_state=3', $page['t3ver_oid']), $fields = '*');
-			//$page = t3lib_BEfunc::getRecord('pages', $page['t3ver_move_id']);
 		}
 		return $page;
 	}
@@ -230,35 +214,27 @@ class Tx_Fluidpages_Service_PageService implements t3lib_Singleton {
 	 * @api
 	 */
 	public function getPageFlexFormSource($pageUid) {
+		$pageUid = intval($pageUid);
+		if (1 > $pageUid) {
+			return NULL;
+		}
+		$workspaceId = intval($GLOBALS['BE_USER']->workspace);
+		$cacheKey = 'flexform_uid' . $pageUid . '_wsid' . $workspaceId;
+		if (TRUE === isset(self::$cache[$cacheKey])) {
+			return self::$cache[$cacheKey];
+		}
+		$page = $this->getPage($pageUid);
+		while (0 !== intval($page['uid']) && TRUE === empty($page['tx_fed_page_flexform'])) {
+			$page = $this->getPageParent($page);
+		};
+		if (empty($page['tx_fed_page_flexform'])) {
+			self::$cache[$cacheKey] = NULL;
+			return NULL;
+		}
+		self::$cache[$cacheKey] = $page['tx_fed_page_flexform'];
+		return $page['tx_fed_page_flexform'];
 
-        $pageUid  = (int)$pageUid;
-        $wsId     = (int)$GLOBALS['BE_USER']->workspace;
-        $cacheKey = 'flexform_uid' . $pageUid . '_wsid' . $wsId;
-
-        if ( $pageUid < 1 ) {
-            return NULL;
-        }
-
-        if (TRUE === isset(self::$cache[$cacheKey])) {
-            return self::$cache[$cacheKey];
-        }
-
-        $page = $this->getPage($pageUid);
-
-        while ($page['uid'] != 0 && empty($page['tx_fed_page_flexform'])) {
-            $page = $this->getPageParent($page);
-        };
-
-        if (empty($page['tx_fed_page_flexform'])) {
-            self::$cache[$cacheKey] = NULL;
-            return NULL;
-        }
-
-        self::$cache[$cacheKey] = $page['tx_fed_page_flexform'];
-
-        return $page['tx_fed_page_flexform'];
-
-    }
+	}
 
 	/**
 	 * Gets a human-readable label from a Fluid Page template file


### PR DESCRIPTION
At first: Bear with me :) This is my first PR

I noticed some troubles in workspace-mode, so I have rewritten some parts in the methods: getPageTemplateConfiguration() and getPageFlexFormSource().
For an easier handling I have added to Functions:
- getPage($pageUid), which returns the right page array depending on workspace-mode
- getPageParent($page), which returns the right parent page

Workspaces currently works only in single-domain setups starting in a low page level.
I have written a small bugfix for the extbase core that will fix this (http://forge.typo3.org/issues/49437)

kind regards
heiko
