### PR TITLE
[BUGFIX] No positions in new content element wizard

### DIFF
--- a/Classes/Backend/BackendLayout.php
+++ b/Classes/Backend/BackendLayout.php
@@ -105,9 +105,9 @@ class Tx_Fluidpages_Backend_BackendLayout implements t3lib_Singleton {
 		}
 
 		$config = array(
-			'colCount' => 0,
-			'rowCount' => 0,
 			'backend_layout.' => array(
+				'colCount' => 0,
+				'rowCount' => 0,
 				'rows.' => array()
 			)
 		);
@@ -122,7 +122,7 @@ class Tx_Fluidpages_Backend_BackendLayout implements t3lib_Singleton {
 				$key = ($index + 1) . '.';
 				$columns[$key] = array(
 					'name' => $column['name'],
-					'colPos' => $column['colPos'] >= 0 ? $column['colPos'] : $config['colCount'],
+					'colPos' => $column['colPos'] >= 0 ? $column['colPos'] : $config['backend_layout.']['colCount']
 				);
 				if ($column['colspan']) {
 					$columns[$key]['colspan'] = $column['colspan'];
@@ -134,8 +134,8 @@ class Tx_Fluidpages_Backend_BackendLayout implements t3lib_Singleton {
 				array_push($items, array($columns[$key]['name'], $columns[$key]['colPos'], NULL));
 				$colCount += $column['colspan'] ? $column['colspan'] : 1;
 			}
-			$config['colCount'] = max($config['colCount'], $colCount);
-			$config['rowCount']++;
+			$config['backend_layout.']['colCount'] = max($config['backend_layout.']['colCount'], $colCount);
+			$config['backend_layout.']['rowCount']++;
 			$config['backend_layout.']['rows.'][$rowKey] = array(
 				'columns.' => $columns
 			);

--- a/Classes/Override/Backend/View/PageLayoutView.php
+++ b/Classes/Override/Backend/View/PageLayoutView.php
@@ -74,6 +74,8 @@ class Tx_Fluidpages_Override_Backend_View_PageLayoutView extends TYPO3\CMS\Backe
 			$config = array();
 			$this->backendLayout->postProcessBackendLayout($this->id, $config);
 			$typoScriptArray = $config['__config'];
+			$typoScriptArray['colCount'] = $config['__config']['backend_layout.']['colCount'];
+			$typoScriptArray['rowCount'] = $config['__config']['backend_layout.']['rowCount'];
 			$typoScriptArray['rows.'] = $config['__config']['backend_layout.']['rows.'];
 			unset($typoScriptArray['backend_layout.']);
 			$config['config'] = $this->compactTypoScriptArray(array('backend_layout.' => $typoScriptArray));


### PR DESCRIPTION
Issue: Click inside the WEB module on List -> "Create new record" -> "Click here for wizard!". At "2: Select position:" there will be no positions to select from.

This issue is caused by an incompatible TS array. In sysext/backend/Classes/Tree/View/PagePositionMap.php colCount and rowCount are expected inside config__.backend_layout but are direclty under config__.

This issue is fixed by moving colCount and rowCount inside config__.backend_layout.
