### PR TITLE
[BUGFIX] Changed alias for flex form tools to t3lib_flexformtools

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -58,7 +58,7 @@ class Tx_Fluidpages_Provider_PageProvider extends Tx_Flux_Provider_AbstractProvi
 	protected $configurationSectionName = 'Configuration';
 
 	/**
-	 * @var t3lib_flexFormTools
+	 * @var t3lib_flexformtools
 	 */
 	protected $flexformTool;
 
@@ -81,7 +81,7 @@ class Tx_Fluidpages_Provider_PageProvider extends Tx_Flux_Provider_AbstractProvi
 	 * CONSTRUCTOR
 	 */
 	public function __construct() {
-		$this->flexformTool = t3lib_div::makeInstance('t3lib_flexFormTools');
+		$this->flexformTool = t3lib_div::makeInstance('t3lib_flexformtools');
 	}
 
 	/**


### PR DESCRIPTION
The official alias for flex form tools is `t3lib_flexformtools` per `ClassAliasMap.php`.
