### PR TITLE
[BUGFIX] Typo for classname t3lib_flexformtools

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -81,7 +81,7 @@ class Tx_Fluidpages_Provider_PageProvider extends Tx_Flux_Provider_AbstractProvi
 	 * CONSTRUCTOR
 	 */
 	public function __construct() {
-		$this->flexformTool = t3lib_div::makeInstance('t3lib_flexFormTools');
+		$this->flexformTool = t3lib_div::makeInstance('t3lib_flexformtools');
 	}
 
 	/**


### PR DESCRIPTION
t3lib_flexformtools is not written in lowerCamelCase.

Its defined as "t3lib_flexformtools" but its instatiated with "t3lib_flexFormTools"

This is a typo and has to be fixed - later Migration ClassAliasMapping would also fail because this is also only defined for the correct naming.
