### PR TITLE
[BUGFIX] Fixed retrieving layouts when root has no controller action

### DIFF
--- a/Classes/Backend/PageLayoutSelector.php
+++ b/Classes/Backend/PageLayoutSelector.php
@@ -89,7 +89,6 @@ class Tx_Fluidpages_Backend_PageLayoutSelector {
 				$selector .= '</label>' . LF;
 			}
 		}
-		$provider = $this->configurationService->resolvePrimaryConfigurationProvider('pages', 'tx_fed_page_flexform', $parameters['row']);
 		foreach ($availableTemplates as $extension=>$group) {
 			if (FALSE === t3lib_extMgm::isLoaded($extension)) {
 				$groupTitle = ucfirst($extension);
@@ -103,7 +102,7 @@ class Tx_Fluidpages_Backend_PageLayoutSelector {
 			$selector .= '<h4 style="clear: both; margin-top: 1em;">' . $packageLabel . ': ' . $groupTitle . '</h4>' . LF;
 			foreach ($group as $template) {
 				try {
-					$paths = $provider->getTemplatePaths($parameters['row']);
+					$paths = $this->configurationService->getPageConfiguration($extension);
 					$extensionName = t3lib_div::underscoredToUpperCamelCase($extension);
 					$templatePathAndFilename = $this->pageService->expandPathsAndTemplateFileToTemplatePathAndFilename($paths, $template);
 					if (FALSE === file_exists($templatePathAndFilename)) {

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -327,6 +327,9 @@ class Tx_Fluidpages_Service_PageService implements t3lib_Singleton {
 		if (TRUE === file_exists($template)) {
 			$templatePathAndFilename = $template;
 		} else {
+			if (TRUE === is_array($paths) && FALSE === empty($paths)) {
+				$paths = Tx_Flux_Utility_Path::translatePath($paths);
+			}
 			$templatePathAndFilename = rtrim($paths['templateRootPath'], '/') . '/Page/' . $template . '.html';
 		}
 		return $templatePathAndFilename;


### PR DESCRIPTION
Was bugged with FluidTYPO3/fluidpages#98

We can't actually use the `$provider->getTemplatePaths` as this only respects the controller actions extension or the one supplied by `AbstractProvider`. Should iterate over all available extensions.
