### PR TITLE
[FEATURE] Added fluidpages sub inheritance

### DIFF
--- a/Classes/UserFunction/NoSubPageConfiguration.php
+++ b/Classes/UserFunction/NoSubPageConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * @author Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
+ * @package	Fluidpages
+ * @subpackage UserFunction
+ */
+class Tx_Fluidpages_UserFunction_NoSubPageConfiguration {
+
+	/**
+	 * @param array $parameters Not used
+	 * @param object $pObj Not used
+	 * @return string
+	 */
+	public function renderField(&$parameters, &$pObj) {
+		unset($pObj, $parameters);
+		return Tx_Extbase_Utility_Localization::translate('pages.tx_fed_page_no_sub_page_configuration', 'Fluidpages');
+	}
+}

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -10,16 +10,22 @@
 			<label index="pages.tx_fed_page_controller_action.default">Parent decides</label>
 			<label index="pages.tx_fed_page_controller_action_sub">Page Layout - subpages</label>
 			<label index="pages.tx_fed_page_flexform">Page Configuration</label>
+			<label index="pages.tx_fed_page_flexform_sub">Page Configuration - subpages</label>
 			<label index="pages.tx_fed_page_package">Package</label>
 			<label index="pages.tx_fed_page_layoutselect">Page Layouts</label>
+			<label index="pages.tx_fed_page_configuration">Page Configuration</label>
+			<label index="pages.tx_fed_page_no_sub_page_configuration">There are no options to configure as your "Page Layout - subpages" is the same as your "Page Layout - this page".</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="pages.tx_fed_page_controller_action">Seitenlayout - diese Seite</label>
 			<label index="pages.tx_fed_page_controller_action.default">wie übergeordnete Seite</label>
 			<label index="pages.tx_fed_page_controller_action_sub">Seitenlayout - Unterseiten</label>
 			<label index="pages.tx_fed_page_flexform">Seitenkonfiguration</label>
+			<label index="pages.tx_fed_page_flexform_sub">Seitenkonfiguration - Unterseiten</label>
 			<label index="pages.tx_fed_page_package">Paket</label>
 			<label index="pages.tx_fed_page_layoutselect">Seitenlayouts</label>
+			<label index="pages.tx_fed_page_configuration">Seitenkonfiguration</label>
+			<label index="pages.tx_fed_page_no_sub_page_configuration">Es gibt keine Optionen zum konfigurieren, da das "Seitenlayout - Unterseiten" das gleiche wie "Seitenlayout - diese Seite" ist.</label>
 		</languageKey>
 	</data>
 </T3locallang>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,7 +17,7 @@ Tx_Extbase_Utility_Extension::configurePlugin(
 	Tx_Extbase_Utility_Extension::PLUGIN_TYPE_PLUGIN
 );
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] == '' ? '' : ',') . 'tx_fed_page_controller_action,tx_fed_page_controller_action_sub,tx_fed_page_flexform,';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] == '' ? '' : ',') . 'tx_fed_page_controller_action,tx_fed_page_controller_action_sub,tx_fed_page_flexform,tx_fed_page_flexform_sub,';
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Backend\\View\\BackendLayoutView'] =
 	array('className' => 'Tx_Fluidpages_Override_Backend_View_BackendLayoutView');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -35,26 +35,31 @@ t3lib_extMgm::addTCAcolumns('pages', array(
 			'type' => 'flex',
 		)
 	),
+	'tx_fed_page_flexform_sub' => Array (
+		'exclude' => 1,
+		'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xml:pages.tx_fed_page_flexform_sub',
+		'config' => array (
+			'type' => 'flex',
+		)
+	),
 ), 1);
 
 $doktypes = '0,1,4';
-$fields = 'tx_fed_page_controller_action,tx_fed_page_controller_action_sub,tx_fed_page_flexform';
-$position = 'before:layout';
 $additionalDoktypes = trim($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['doktypes'], ',');
-t3lib_extMgm::addToAllTCAtypes(
-	'pages',
-	$fields,
-	$doktypes,
-	$position
-);
-
 if (FALSE === empty($additionalDoktypes)) {
-	$fields = '--div--;LLL:EXT:fluidpages/Resources/Private/Language/locallang.xml:pages.tx_fed_page_layoutselect,' . $fields;
-	t3lib_extMgm::addToAllTCAtypes(
-		'pages',
-		$fields,
-		$additionalDoktypes
-	);
+	$doktypes .= ',' . $additionalDoktypes;
 }
 
-unset($doktypes, $fields, $position, $additionalDoktypes);
+t3lib_extMgm::addToAllTCAtypes(
+	'pages',
+	'--div--;LLL:EXT:fluidpages/Resources/Private/Language/locallang.xml:pages.tx_fed_page_layoutselect,tx_fed_page_controller_action,tx_fed_page_controller_action_sub',
+	$doktypes
+);
+
+t3lib_extMgm::addToAllTCAtypes(
+	'pages',
+	'--div--;LLL:EXT:fluidpages/Resources/Private/Language/locallang.xml:pages.tx_fed_page_configuration,tx_fed_page_flexform,tx_fed_page_flexform_sub',
+	$doktypes
+);
+
+unset($doktypes, $additionalDoktypes);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,6 +3,7 @@
 #
 CREATE TABLE pages (
 	tx_fed_page_flexform text NOT NULL,
+	tx_fed_page_flexform_sub text NOT NULL,
 	tx_fed_page_controller_action varchar(255) DEFAULT '' NOT NULL,
 	tx_fed_page_controller_action_sub varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
Enables an additional "Page configuration" field with a Flux form which gets used if the "Page layout - subpages" field is set to use another template than the current page. Filling in this additional Flux form inserts template variables which will be used by subpages only.

Additionally, both "Page configuration" fields have been moved to a tab of their own.
### Page properties update warning

Please note that a fallback has been implemented which makes fluidpages read variables exactly like before this change _right up until you save your pages_. This means that _when you save pages after installing this feature, you **must** make sure the "Page Configuration - subpages" field is configured._ If you do not ensure this you risk sub pages inheriting empty or unexpected values (since variables now come from the secondary field).
### Database update warning

This feature requires running the install tool's DB comparison wizard or manually adding the field documented in `ext_tables.sql`.

Needs FluidTYPO3/flux#357
Fixes #61
