### PR TITLE
[BUGFIX] Fallback to column name if no label is given for a column

### DIFF
--- a/Classes/Backend/BackendLayout.php
+++ b/Classes/Backend/BackendLayout.php
@@ -126,11 +126,11 @@ class BackendLayout implements SingletonInterface {
 			$colCount = 0;
 			$rowKey = ($rowIndex + 1) . '.';
 			$columns = array();
-			foreach ($row['columns'] as $name => $column) {
+			foreach ($row['columns'] as $column) {
 				$key = ($index + 1) . '.';
 				$columnName = $GLOBALS['LANG']->sL($column['label']);
-				if (NULL === $columnName) {
-					$columnName = $column['label'];
+				if (TRUE === empty($columnName)) {
+					$columnName = $column['name'];
 				}
 				$columns[$key] = array(
 					'name' => $columnName,


### PR DESCRIPTION
If no label is given for a column as shown in the example below, the attribute "name" is not displayed in module Page nor in field "colPos".

```
<flux:flexform.grid>
    <flux:flexform.grid.row>
        <flux:flexform.grid.column colPos="0" name="Main Content"/>
        <flux:flexform.grid.column colPos="2" name="Sidebar Content"/>
    </flux:flexform.grid.row>
</flux:flexform.grid>
```
