### PR TITLE
[BUGFIX] Make url of included js file absolute

### DIFF
--- a/Classes/Override/Backend/View/PageLayoutView.php
+++ b/Classes/Override/Backend/View/PageLayoutView.php
@@ -169,7 +169,9 @@ class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView {
 		$showHidden = $this->tt_contentConfig['showHidden'] ? '' : \TYPO3\CMS\Backend\Utility\BackendUtility::BEenableFields('tt_content');
 		$pageTitleParamForAltDoc = '&recTitle=' . rawurlencode(\TYPO3\CMS\Backend\Utility\BackendUtility::getRecordTitle('pages', \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordWSOL('pages', $id), TRUE));
 		$GLOBALS['SOBE']->doc->getPageRenderer()->loadExtJs();
-		$GLOBALS['SOBE']->doc->getPageRenderer()->addJsFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('fluidpages') . 'Resources/Public/js/typo3pageModule.js');
+		$siteUrl = \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
+		$jsPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('fluidpages') . 'Resources/Public/js/typo3pageModule.js';
+		$GLOBALS['SOBE']->doc->getPageRenderer()->addJsFile($siteUrl . $jsPath);
 		// Get labels for CTypes and tt_content element fields in general:
 		$this->CType_labels = array();
 		foreach ($GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'] as $val) {


### PR DESCRIPTION
The file to be included couldn't be found in some backend situations in 6.2 due to a relative url breaking the js thus making it impossible to add content.
