### PR TITLE
[TASK] Implement DataProvider for 6.2

### DIFF
--- a/Classes/Backend/PageLayoutSelector.php
+++ b/Classes/Backend/PageLayoutSelector.php
@@ -61,10 +61,10 @@ class PageLayoutSelector {
 	 * CONSTRUCTOR
 	 */
 	public function __construct() {
-		$objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-		$this->configurationManager = $objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
-		$this->configurationService = $objectManager->get('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService');
-		$this->pageService = $objectManager->get('FluidTYPO3\\Fluidpages\\Service\\PageService');
+		$objectManager = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+		$this->configurationManager = $objectManager->get('TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager');
+		$this->configurationService = $objectManager->get('FluidTYPO3\Fluidpages\Service\ConfigurationService');
+		$this->pageService = $objectManager->get('FluidTYPO3\Fluidpages\Service\PageService');
 	}
 
 	/**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,7 +20,5 @@ if (!defined ('TYPO3_MODE')) {
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] == '' ? '' : ',') . 'tx_fed_page_controller_action,tx_fed_page_controller_action_sub,tx_fed_page_flexform,tx_fed_page_flexform_sub,';
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Backend\\View\\BackendLayoutView'] =
-	array('className' => 'FluidTYPO3\Fluidpages\Override\Backend\View\BackendLayoutView');
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\\CMS\\Backend\\View\\PageLayoutView'] =
-	array('className' => 'FluidTYPO3\Fluidpages\Override\Backend\View\PageLayoutView');
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['BackendLayoutDataProvider']['fluidpages'] = 'FluidTYPO3\Fluidpages\Backend\BackendLayoutDataProvider';
+


### PR DESCRIPTION
NOTE: includes a regression - our custom css/js no longer included, core has fixed the jumpiness issues we were experiencing. Regression by this commit: can no longer drag-n-drop content element below container element into first column of container element (known bug from earlier).
