### PR TITLE
[TASK] TYPO3 installtool SQL compare

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -4,8 +4,8 @@
 CREATE TABLE pages (
 	tx_fluidpages_templatefile varchar(255) DEFAULT NULL,
 	tx_fluidpages_layout varchar(64) DEFAULT NULL,
-	tx_fed_page_flexform text DEFAULT '' NOT NULL,
-	tx_fed_page_flexform_sub text DEFAULT '' NOT NULL,
+	tx_fed_page_flexform text NOT NULL,
+	tx_fed_page_flexform_sub text NOT NULL,
 	tx_fed_page_controller_action varchar(255) DEFAULT '' NOT NULL,
 	tx_fed_page_controller_action_sub varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
TYPO3 don't support DEFAULT '' in SQL compare and want always to alter the columns
This should be no problem. Text is always empty.
