### PR TITLE
[BUGFIX] Provide ext conf in ext_tables

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,6 +2,7 @@
 if (!defined ('TYPO3_MODE')) {
 	die ('Access denied.');
 }
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup'] = unserialize($_EXTCONF);
 
 \FluidTYPO3\Flux\Core::unregisterConfigurationProvider('Tx_Fed_Provider_Configuration_PageConfigurationProvider');
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\PageProvider');


### PR DESCRIPTION
In ext_tables we need that setup to be present to access the additional doktypes
