### PR TITLE
[BUGFIX] Fix method getPageParrent in workspace mode

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -157,9 +157,9 @@ class PageService implements SingletonInterface {
 	 */
 	protected function getPageParent($page) {
 		// try to get the original page
-		$live = BackendUtility::getLiveVersionIdOfRecord('pages', intval($page['uid']));
-		$live = NULL === $live ? $page : $live;
-		return $this->getPage($live['pid']);
+		$liveUid = BackendUtility::getLiveVersionIdOfRecord('pages', intval($page['uid']));
+		$page = NULL !== $liveUid ? BackendUtility::getRecord('pages', $liveUid, '*') : $page;
+		return $this->getPage($page['pid']);
 	}
 
 	/**


### PR DESCRIPTION
The method "getPageParent($page)" in "FluidTYPO3\Fluidpages\Service\PageService" runns into troubles if "BackendUtility::getLiveVersionIdOfRecord" returns a valid value (WorkspaceId). The solution is more complicated than the first look, cause the Method "getPage()" alway returns a workspace-version (if possible), but in this case the live-version is needed.
