### PR TITLE
[BUGFIX] Page module does not show FluidPage

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -24,7 +24,7 @@ if (FALSE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup'
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] == '' ? '' : ',') . 'tx_fed_page_controller_action,tx_fed_page_controller_action_sub,tx_fed_page_flexform,tx_fed_page_flexform_sub,';
 
-if (6.2 <= (float) substr(TYPO3_version, 0, 3)) {
+if (6.2 > (float) substr(TYPO3_version, 0, 3)) {
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['BackendLayoutDataProvider']['fluidpages'] =
 		'FluidTYPO3\Fluidpages\Backend\BackendLayoutDataProvider';
 } else {


### PR DESCRIPTION
Page module in the backend shows always the TYPO3 basic backend grid and not the FluidPage layout.

Tested TYPO3 Version: 6.2.5
