### PR TITLE
[BUGFIX] Support unassigned content areas

### DIFF
--- a/Classes/Backend/BackendLayoutDataProvider.php
+++ b/Classes/Backend/BackendLayoutDataProvider.php
@@ -190,7 +190,7 @@ class BackendLayoutDataProvider implements DataProviderInterface {
 				}
 				$columns[$key] = array(
 					'name' => $columnName,
-					'colPos' => $column['colPos'] >= 0 ? $column['colPos'] : $config['colCount']
+					'colPos' => $column['colPos'] >= 0 ? $column['colPos'] : null
 				);
 				if ($column['colspan']) {
 					$columns[$key]['colspan'] = $column['colspan'];


### PR DESCRIPTION
The TYPO3 core allows to have columns/content areas that are not assigned to a column 
in the tt_content table/colPos column. These unassigned columns are displayed as a shaded
area and do not allow to create content. This is helpful to represent areas in the backend 
which are visible in the frontend but controlled by other means like plugins, banners, or 
hardcoded content.

To mark a content area as unassigned it is enough to not provide a colPos key in the backend 
layout configuration. Previously 0 would have been assigned as a default, which might not be 
correct or wanted, too.
