### PR TITLE
Hook that removes colpos 18181 sthat hows up as column in language mode

### DIFF
--- a/Classes/Hooks/BackendDocumentTemplate.php
+++ b/Classes/Hooks/BackendDocumentTemplate.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * User: robsonrobi
+ * Date: 04.02.15
+ * Time: 16:56
+ */
+
+namespace FluidTYPO3\Fluidpages\Hooks;
+
+
+class BackendDocumentTemplate {
+
+    /**
+     * Hook after rendering a page in the backend to remove the section "Fluid Content Area" produced by the colpos 18181
+     *
+     * @param array $params
+     * @param  \TYPO3\CMS\Backend\Template\DocumentTemplate $template
+     * @return void
+     */
+    public function removeFluidContentAreaSection(array $params, \TYPO3\CMS\Backend\Template\DocumentTemplate &$template) {
+        /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
+        $pageRenderer = $template->getPageRenderer();
+
+        $jsCode = "Ext.onReady(function() {
+             function contains(selector, text) {
+                 var elements = document.querySelectorAll(selector);
+                 return [].filter.call(elements, function(element){
+                    return RegExp(text).test(element.textContent);
+                 });
+             }
+             var childs = contains('div', /^Fluid\ Content\ Area$/);
+             childs.forEach(function(element, index, array){
+                var remove = element.parentNode.parentNode;
+                var removeParent = remove.parentNode;
+                removeParent.removeChild(remove);
+             });
+         });";
+
+        $pageRenderer->addHeaderData('<script type="text/javascript">' . $jsCode . '</script>');
+    }
+
+} 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,3 +25,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['BackendLayoutDataProvider']['fluidpages'] =
 	'FluidTYPO3\Fluidpages\Backend\BackendLayoutDataProvider';
+
+if (TYPO3_MODE === 'BE') {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/template.php']['preHeaderRenderHook'][] = 'FluidTYPO3\\Fluidpages\\Hooks\\BackendDocumentTemplate->removeFluidContentAreaSection';
+}


### PR DESCRIPTION
After rendering a page in the page end, the hook [preHeaderRenderHook] is executed and a small javascript snippet is inserted into the head, that removes the section "Fluid Content Area".
