### PR TITLE
[TASK] Switch to new Flux TemplatePaths/ViewContext objects

### DIFF
--- a/Classes/Backend/BackendLayoutDataProvider.php
+++ b/Classes/Backend/BackendLayoutDataProvider.php
@@ -168,7 +168,6 @@ class BackendLayoutDataProvider implements DataProviderInterface {
 				$this->configurationService->message('No template selected - backend layout will not be rendered', GeneralUtility::SYSLOG_SEVERITY_INFO);
 				return array();
 			}
-			$paths = $provider->getTemplatePaths($record);
 			$grid = $provider->getGrid($record)->build();
 			if (FALSE === is_array($grid) || 0 === count($grid['rows'])) {
 				// no grid is defined; we use the "raw" BE layout as a default behavior

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -17,6 +17,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\PathUtility;
 use FluidTYPO3\Flux\Utility\ResolveUtility;
+use FluidTYPO3\Flux\View\TemplatePaths;
 use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -130,12 +131,14 @@ class PageProvider extends AbstractProvider implements ProviderInterface {
 	 * @return string
 	 */
 	public function getTemplatePathAndFilename(array $row) {
-		$action = $this->getControllerActionReferenceFromRecord($row);
-		$paths = $this->getTemplatePaths($row);
 		$templatePathAndFilename = $this->templatePathAndFilename;
+		$action = $this->getControllerActionReferenceFromRecord($row);
 		if (FALSE === empty($action)) {
+			$paths = $this->getTemplatePaths($row);
+			$templatePaths = new TemplatePaths($paths);
 			list (, $action) = explode('->', $action);
-			$templatePathAndFilename = ResolveUtility::resolveTemplatePathAndFilenameByPathAndControllerNameAndActionAndFormat($paths, 'Page', $action);
+			$action = ucfirst($action);
+			$templatePathAndFilename = $templatePaths->resolveTemplateFileForControllerAndActionAndFormat('Page', $action);
 		}
 		return $templatePathAndFilename;
 	}

--- a/Tests/Unit/Backend/PageLayoutSelectorTest.php
+++ b/Tests/Unit/Backend/PageLayoutSelectorTest.php
@@ -126,13 +126,11 @@ class PageLayoutSelectorTest extends UnitTestCase {
 		$instance = new PageLayoutSelector();
 		$service = $this->getMock(
 			'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
-			array(
-				'getPageConfiguration', 'expandPathsAndTemplateFileToTemplatePathAndFilename',
-				'getFormFromTemplateFile', 'message', 'debug'
-			)
+			array('getPageConfiguration', 'getFormFromTemplateFile', 'message', 'debug')
 		);
-		$service->expects($this->any())->method('getPageConfiguration')->willReturn(array());
-		$service->expects($this->any())->method('expandPathsAndTemplateFileToTemplatePathAndFilename')->willReturn($file);
+		$service->expects($this->any())->method('getPageConfiguration')->willReturn(array(
+			'templateRootPaths' => 'EXT:fluidpages/Tests/Fixtures/Templates/'
+		));
 		$service->expects($this->any())->method('getFormFromTemplateFile')->willReturn($form);
 		if (NULL !== $expectedMessageFunction) {
 			$service->expects($this->once())->method($expectedMessageFunction);
@@ -151,7 +149,7 @@ class PageLayoutSelectorTest extends UnitTestCase {
 	 * @return array
 	 */
 	public function getRenderOptionTestValues() {
-		$validFile = ExtensionManagementUtility::extPath('fluidpages', 'Tests/Fixtures/Templates/Page/Dummy.html');
+		$validFile = 'Dummy';
 		$disabledForm = $this->getMock('FluidTYPO3\\Flux\\Form', array('getEnabled'));
 		$disabledForm->expects($this->once())->method('getEnabled')->willReturn(FALSE);
 		$exceptionForm = $this->getMock('FluidTYPO3\\Flux\\Form', array('getEnabled'));


### PR DESCRIPTION
This change makes Fluidpages' classes utilise the new components of Flux which hold a view context and template path collections.

Depends: https://github.com/FluidTYPO3/flux/pull/758