### PR TITLE
[TASK] Get rid of the deprecation log

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -40,7 +40,7 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
 			'type' => 'flex',
 		)
 	),
-), 1);
+));
 
 $doktypeIcon = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('fluidpages') . 'doktype_icon.png';
 


### PR DESCRIPTION
Deprecated method. I don't want the message => `Usage of feInterface is
no longer part of the TYPO3 CMS Core` anymore ;-) ... and since core min. is 6.2 that's no problem.