### PR TITLE
[BUGFIX] Correctly resolve Page vs. SubPageProvider, use page provider resolution for BackendLayoutConfiguration

### DIFF
--- a/Classes/Backend/BackendLayoutDataProvider.php
+++ b/Classes/Backend/BackendLayoutDataProvider.php
@@ -8,7 +8,6 @@ namespace FluidTYPO3\Fluidpages\Backend;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Fluidpages\Provider\PageProvider;
 use FluidTYPO3\Fluidpages\Service\ConfigurationService;
 use FluidTYPO3\Fluidpages\Service\PageService;
 use FluidTYPO3\Flux\Service\ContentService;
@@ -163,7 +162,7 @@ class BackendLayoutDataProvider implements DataProviderInterface {
 				return array();
 			}
 
-			$provider = $this->configurationService->resolvePrimaryConfigurationProvider('pages', NULL, $record);
+			$provider = $this->configurationService->resolvePageProvider($record);
 			$action = $provider->getControllerActionFromRecord($record);
 			if (TRUE === empty($action)) {
 				$this->configurationService->message('No template selected - backend layout will not be rendered', GeneralUtility::SYSLOG_SEVERITY_INFO);

--- a/Classes/Controller/PageController.php
+++ b/Classes/Controller/PageController.php
@@ -70,11 +70,7 @@ class PageController extends AbstractFluxController implements PageControllerInt
 	 * @return void
 	 */
 	protected function initializeProvider() {
-		$row = $this->getRecord();
-		$configuration = $this->pageService->getPageTemplateConfiguration($row['uid']);
-		$hasMainAction = TRUE === empty($row[PageProvider::FIELD_ACTION_MAIN]);
-		$fieldName = TRUE === $hasMainAction ? PageProvider::FIELD_NAME_MAIN : PageProvider::FIELD_NAME_SUB;
-		$this->provider = $this->configurationService->resolvePrimaryConfigurationProvider($this->fluxTableName, $fieldName, $row);
+		$this->provider = $this->configurationService->resolvePageProvider($this->getRecord());
 	}
 
 	/**

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -8,10 +8,10 @@ namespace FluidTYPO3\Fluidpages\Service;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Fluidpages\Provider\PageProvider;
 use FluidTYPO3\Flux\Core;
+use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Service\FluxService;
-use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
-use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -92,5 +92,21 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 		}
 		return $configurations;
 	}
+
+	/**
+	 * Resolve fluidpages specific configuration provider.
+	 *
+	 * @param array $row
+	 *
+	 * @return ProviderInterface|NULL
+	 */
+	public function resolvePageProvider($row) {
+		$hasMainAction = FALSE === empty($row[PageProvider::FIELD_ACTION_MAIN]);
+		$fieldName = TRUE === $hasMainAction ? PageProvider::FIELD_NAME_MAIN : PageProvider::FIELD_NAME_SUB;
+		$provider = $this->resolvePrimaryConfigurationProvider('pages', $fieldName, $row);
+
+		return $provider;
+	}
+
 
 }


### PR DESCRIPTION
This fixes

1. a wrong comparison in the computation of `$hasMainAction` (*)
2. and gives `getBackendLayoutConfiguration()` the correct page provider

(\*) this might have been avoided *without* "Yoda conditions and explicit comparisons": compare
```php
$hasMainAction = TRUE === empty($row[PageProvider::FIELD_ACTION_MAIN]);
```
and
```php
$hasMainAction = !empty($row[PageProvider::FIELD_ACTION_MAIN]);
```
