### PR TITLE
[TASK] Hide package label in page layout selector if no page layouts are provided

### DIFF
--- a/Classes/Backend/PageLayoutSelector.php
+++ b/Classes/Backend/PageLayoutSelector.php
@@ -133,19 +133,21 @@ class PageLayoutSelector {
 	 */
 	protected function renderOptions($extension, array $group, array $parameters) {
 		$selector = '';
-		$extensionKey = ExtensionNamingUtility::getExtensionKey($extension);
-		if (FALSE === ExtensionManagementUtility::isLoaded($extensionKey)) {
-			$groupTitle = ucfirst($extension);
-		} else {
-			$emConfigFile = ExtensionManagementUtility::extPath($extensionKey, 'ext_emconf.php');
-			require $emConfigFile;
-			$groupTitle = $EM_CONF['']['title'];
-		}
+		if (FALSE === empty($group)) {
+			$extensionKey = ExtensionNamingUtility::getExtensionKey($extension);
+			if (FALSE === ExtensionManagementUtility::isLoaded($extensionKey)) {
+				$groupTitle = ucfirst($extension);
+			} else {
+				$emConfigFile = ExtensionManagementUtility::extPath($extensionKey, 'ext_emconf.php');
+				require $emConfigFile;
+				$groupTitle = $EM_CONF['']['title'];
+			}
 
-		$packageLabel = LocalizationUtility::translate('pages.tx_fed_page_package', 'Fluidpages');
-		$selector .= '<h4 style="clear: both; margin-top: 1em;">' . $packageLabel . ': ' . $groupTitle . '</h4>' . LF;
-		foreach ($group as $template) {
-			$selector .= $this->renderOption($extension, $template, $parameters);
+			$packageLabel = LocalizationUtility::translate('pages.tx_fed_page_package', 'Fluidpages');
+			$selector .= '<h4 style="clear: both; margin-top: 1em;">' . $packageLabel . ': ' . $groupTitle . '</h4>' . LF;
+			foreach ($group as $template) {
+				$selector .= $this->renderOption($extension, $template, $parameters);
+			}
 		}
 		return $selector;
 	}


### PR DESCRIPTION
This patch makes ``PageLayoutSelector->renderOptions()`` return an empty string and thus does not render the package label if the provider extension does not provide any page layouts. See https://github.com/FluidTYPO3/flux/issues/839#issuecomment-105763399

Second try (see https://github.com/FluidTYPO3/fluidpages/pull/260), now following the CGL.