### PR TITLE
[BUGFIX] Add 6.2.x compatability

### DIFF
--- a/Classes/Backend/BackendLayoutDataProvider.php
+++ b/Classes/Backend/BackendLayoutDataProvider.php
@@ -229,7 +229,7 @@ class BackendLayoutDataProvider implements DataProviderInterface {
 	 * @return boolean
 	 */
 	protected function isPageModuleLanguageView() {
-		$module = GeneralUtility::_GET('M');
+		$module = GeneralUtility::_GET('M') ? GeneralUtility::_GET('M') : 'web_layout';
 		$function = TRUE === isset($GLOBALS['SOBE']->MOD_SETTINGS['function']) ? $GLOBALS['SOBE']->MOD_SETTINGS['function'] : NULL;
 		return ('web_layout' === $module && 2 === (integer) $function);
 	}


### PR DESCRIPTION
Since 6.2.x doesn't have a get parameter 'M'
this commit adds a fallback to make hide the
colPos 18181 in page language view.