### PR TITLE
[FEATURE] Allow "HeaderCode" section in page templates

### DIFF
--- a/Classes/Controller/PageController.php
+++ b/Classes/Controller/PageController.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Controller\AbstractFluxController;
 use FluidTYPO3\Fluidpages\Service\PageService;
 use FluidTYPO3\Fluidpages\Service\ConfigurationService;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Extbase\Mvc\Web\Response;
 
 /**
  * Page Controller
@@ -41,6 +42,11 @@ class PageController extends AbstractFluxController implements PageControllerInt
 	protected $configurationService;
 
 	/**
+	 * @var Response
+	 */
+	protected $response;
+
+	/**
 	 * @param PageService $pageService
 	 */
 	public function injectPageService(PageService $pageService) {
@@ -60,8 +66,12 @@ class PageController extends AbstractFluxController implements PageControllerInt
 	 * @return void
 	 */
 	public function initializeView(ViewInterface $view) {
-		$this->configurationManager->getContentObject()->data = $this->getRecord();
+		$record = $this->getRecord();
+		$this->configurationManager->getContentObject()->data = $record;
 		parent::initializeView($view);
+		$this->response->addAdditionalHeaderData(
+			(string) $this->view->renderStandaloneSection('HeaderCode', $this->provider->getTemplateVariables($record), TRUE)
+		);
 	}
 
 	/**

--- a/Tests/Unit/Controller/PageControllerTest.php
+++ b/Tests/Unit/Controller/PageControllerTest.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use FluidTYPO3\Fluidpages\Tests\Fixtures\Controller\DummyPageController;
 use FluidTYPO3\Flux\Provider\Provider;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Mvc\Web\Response;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
 /**
@@ -50,7 +51,7 @@ class PageControllerTest extends UnitTestCase {
 
 	public function testInitializeView() {
 		/** @var PageController|\PHPUnit_Framework_MockObject_MockObject $instance */
-		$instance = $this->getMock(
+		$instance = $this->getAccessibleMock(
 			'FluidTYPO3\\Fluidpages\\Controller\\PageController',
 			array(
 				'getRecord', 'initializeProvider', 'initializeSettings', 'initializeOverriddenSettings',
@@ -68,8 +69,10 @@ class PageControllerTest extends UnitTestCase {
 		$instance->expects($this->once())->method('getRecord')->willReturn(array('uid' => 0));
 		$GLOBALS['TSFE'] = (object) array('page' => 'page', 'fe_user' => (object) array('user' => 'user'));
 		/** @var StandaloneView $view */
-		$view = $this->getMock('TYPO3\\CMS\\Fluid\\View\\StandaloneView', array('assign'));
+		$view = $this->getMock('FluidTYPO3\\Flux\\View\\ExposedTemplateView', array('assign', 'renderStandaloneSection'));
 		$instance->injectConfigurationManager($configurationManager);
+		$instance->_set('response', $this->getMock('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Response'));
+		$instance->_set('provider', $this->getMock('FluidTYPO3\\Flux\\Provider\\ProviderInterface'));
 		$instance->initializeView($view);
 	}
 


### PR DESCRIPTION
Enables putting 100% raw content into the `<head></head>` tag TYPO3 creates.