### PR TITLE
[BUGFIX] Only template files of templateRootPaths.0 were used.

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -181,6 +181,10 @@ class PageService implements SingletonInterface {
 					} else if (strtolower($extension) !== strtolower($format)) {
 						continue;
 					}
+					$filename = $pathinfo['filename'];
+					if (isset($output[$extensionName][$filename])) {
+						continue;
+					}
 					$viewContext = new ViewContext($configuredPath . $file, $extensionName, 'Page');
 					$viewContext->setSectionName('Configuration');
 					$viewContext->setTemplatePaths($templatePaths);
@@ -200,7 +204,6 @@ class PageService implements SingletonInterface {
 						continue;
 					}
 
-					$filename = $pathinfo['filename'];
 					$output[$extensionName][$filename] = $form;
 				}
 			}


### PR DESCRIPTION
Missing test of already found form of an overwritten template,
in function getAvailablePageTemplateFiles of PageService.php.
Now the correct configuration section is used.