### PR TITLE
[FEATURE] Replace deprecated configuration translation

### DIFF
--- a/Classes/Provider/PageLanguageOverlayProvider.php
+++ b/Classes/Provider/PageLanguageOverlayProvider.php
@@ -1,0 +1,50 @@
+<?php
+namespace FluidTYPO3\Fluidpages\Provider;
+
+/*
+ * This file is part of the FluidTYPO3/Fluidpages project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Provider\ProviderInterface;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
+/**
+ * Page LanguageOverlayConfiguration Provider
+ *
+ * This Provider takes care of page Configuration
+ * for other languages inside the pages_language_overlay
+ * record.
+ */
+class PageLanguageOverlayProvider extends PageProvider implements ProviderInterface {
+
+	/**
+	 * @var string
+	 */
+	protected $tableName = 'pages_language_overlay';
+
+	/**
+	 * @param array $record
+	 * @return array
+	 */
+	protected function loadRecordTreeFromDatabase($record) {
+		$parentFieldName = $this->getParentFieldName($record);
+		if (FALSE === isset($record[$parentFieldName])) {
+			$record[$parentFieldName] = $this->getParentFieldValue($record);
+		}
+		$pageRecord = $this->recordService->getSingle('pages', '*', $record['pid']);
+		$records = array();
+		while (0 < $pageRecord[$parentFieldName]) {
+			$record = $this->recordService->get($this->tableName, '*', 'pid = ' . $pageRecord['pid']);
+			$parentFieldName = $this->getParentFieldName($record);
+			array_push($records, $record);
+			$pageRecord = $this->recordService->getSingle('pages', '*', $pageRecord['pid']);
+		}
+		$records = array_reverse($records);
+		return $records;
+	}
+
+}

--- a/Classes/Provider/SubPageLanguageOverlayProvider.php
+++ b/Classes/Provider/SubPageLanguageOverlayProvider.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Provider\ProviderInterface;
 
 /**
- * Page SubConfiguration Provider
+ * PageLanguageOverlay SubConfiguration Provider
  *
  * This Provider has a slightly lower priority
  * than the main PageProvider but will trigger
@@ -23,7 +23,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
  * that define a specific action to use and the
  * SubPageProvider act on all other page records.
  */
-class SubPageProvider extends PageProvider implements ProviderInterface {
+class SubPageLanguageOverlayProvider extends PageLanguageOverlayProvider implements ProviderInterface {
 
 	/**
 	 * @var string
@@ -39,6 +39,17 @@ class SubPageProvider extends PageProvider implements ProviderInterface {
 			$row = $this->pageService->getPageTemplateConfiguration($row['uid']);
 		}
 		return $row[self::FIELD_ACTION_SUB];
+	}
+
+	/**
+	 * @param array $row
+	 * @return array
+	 */
+	public function getFlexFormValuesSingle(array $row) {
+		$fieldName = $this->getFieldName($row);
+		$form = $this->getForm($row);
+		$immediateConfiguration = $this->configurationService->convertFlexFormContentToArray($row[$fieldName], $form, NULL, NULL);
+		return $immediateConfiguration;
 	}
 
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,6 @@ autoload = 1
 
   # cat=basic/enable; type=input; label=Doktypes: CSV list of doktypes to add the page layout selectors to in addition to the default standard pages and shortcuts (0,1,4). Possible use cases are sysfolders (254) or custom page types.
 doktypes =
+
+  # cat=basic/enable; type=boolean; label=Enable translation of Page Configuration through the Pages Language Overlays.
+pagesLanguageConfigurationOverlay = 0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,6 +11,8 @@ if (FALSE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup'
 
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\PageProvider');
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\SubPageProvider');
+\FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\PageLanguageOverlayProvider');
+\FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\SubPageLanguageOverlayProvider');
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
 	'FluidTYPO3.Fluidpages',

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -155,3 +155,30 @@ if (FALSE === empty($additionalDoktypes)) {
 $GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ',tx_fluidpages_templatefile';
 
 unset($doktypes, $additionalDoktypes, $doktypeIcon);
+
+if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['pagesLanguageConfigurationOverlay'])
+	&& TRUE === (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['pagesLanguageConfigurationOverlay']) {
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', array(
+		'tx_fed_page_flexform' => Array (
+			'exclude' => 1,
+			'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform',
+			'config' => array (
+				'type' => 'flex',
+			)
+		),
+		'tx_fed_page_flexform_sub' => Array (
+			'exclude' => 1,
+			'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform_sub',
+			'config' => array (
+				'type' => 'flex',
+			)
+		),
+	));
+
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+		'pages_language_overlay',
+		'--div--;LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_configuration,tx_fed_page_flexform,tx_fed_page_flexform_sub'
+	);
+
+	$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_fed_page_flexform,tx_fed_page_flexform_sub';
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -9,3 +9,11 @@ CREATE TABLE pages (
 	tx_fed_page_controller_action varchar(255) DEFAULT '' NOT NULL,
 	tx_fed_page_controller_action_sub varchar(255) DEFAULT '' NOT NULL,
 );
+
+#
+# Table structure for table 'pages_language_overlay'
+#
+CREATE TABLE pages_language_overlay (
+	tx_fed_page_flexform text,
+	tx_fed_page_flexform_sub text
+);


### PR DESCRIPTION
Since TYPO3 7.6 the previous handling of translated page configuration has been deprecated and moved into the compatibility6 extension. To replace this functionality this commit introduces the flexform fields  for configuration to the  pages_language_overlay table and takes care of the overlaying of the affected configurations. This functionality is disable by default and can be activated through a toggle in the extension configuration.

related deprecation: [#70138 - Flex form language handling](https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/7.6/Deprecation-70138-FlexFormLanguageHandling.html#deprecation-70138-flex-form-language-handling)