### PR TITLE
[TASK] Improve performance of PageProvider

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -304,7 +304,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface {
 		$tableName = $this->getTableName($row);
 		$tableFieldName = $this->getFieldName($row);
 		$cacheKey = $tableName . $tableFieldName . $row['uid'];
-		if (TRUE === empty(self::$cache[$cacheKey])) {
+		if (FALSE === isset(self::$cache[$cacheKey])) {
 			$tree = $this->getInheritanceTree($row);
 			$data = array();
 			foreach ($tree as $branch) {

--- a/Tests/Unit/Provider/PageProviderTest.php
+++ b/Tests/Unit/Provider/PageProviderTest.php
@@ -201,6 +201,8 @@ class PageProviderTest extends AbstractTestCase {
 		$form = Form::create();
 		$form->createField('Input', 'foo');
 		$record = $this->getBasicRecord();
+		// use a new uid to prevent caching issues
+		$record['uid'] = $record['uid'] + 1;
 		/** @var DummyPageProvider $dummyProvider1 */
 		$dummyProvider1 = $this->objectManager->get('FluidTYPO3\\Fluidpages\\Tests\\Fixtures\\Provider\\DummyPageProvider');
 		/** @var DummyPageProvider $dummyProvider2 */


### PR DESCRIPTION
we should check for the existence of the Cache key instead of it being empty, because the Inherited Configuration often tends to be empty, which means, we retry this countless of times without any good reason. This results in a exponential growth old load time in relation to the amount of fields in a sheet.

On my MacBook Retina this resulted in ~ 35s load time for 10 simple input fields. 
Here's a little graph, that shows, the growth rate of the load time in relation to the amount of input fields in a page configuration sheet:

![](http://dl.dropbox.com/u/314491/Screenshots/vix3y6ny0w5o.png)
![](http://dl.dropbox.com/u/314491/Screenshots/_4s3k~zleuk-.png)