### PR TITLE
[TASK] More performance improvements

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -286,9 +286,10 @@ class PageProvider extends AbstractProvider implements ProviderInterface {
 	 * @return Form
 	 */
 	protected function setDefaultValuesInFieldsWithInheritedValues(Form $form, array $row) {
+		$inheritedConfiguration = $this->getInheritedConfiguration($row);
 		foreach ($form->getFields() as $field) {
 			$name = $field->getName();
-			$inheritedValue = $this->getInheritedPropertyValueByDottedPath($row, $name);
+			$inheritedValue = $this->getInheritedPropertyValueByDottedPath($inheritedConfiguration, $name);
 			if (NULL !== $inheritedValue && TRUE === $field instanceof Form\FieldInterface) {
 				$field->setDefault($inheritedValue);
 			}
@@ -327,12 +328,11 @@ class PageProvider extends AbstractProvider implements ProviderInterface {
 	}
 
 	/**
-	 * @param array $row
+	 * @param array $inheritedConfiguration
 	 * @param string $propertyPath
 	 * @return mixed
 	 */
-	protected function getInheritedPropertyValueByDottedPath(array $row, $propertyPath) {
-		$inheritedConfiguration = $this->getInheritedConfiguration($row);
+	protected function getInheritedPropertyValueByDottedPath($inheritedConfiguration, $propertyPath) {
 		if (TRUE === empty($propertyPath)) {
 			return NULL;
 		} elseif (FALSE === strpos($propertyPath, '.')) {

--- a/Tests/Unit/Provider/PageProviderTest.php
+++ b/Tests/Unit/Provider/PageProviderTest.php
@@ -250,9 +250,11 @@ class PageProviderTest extends AbstractTestCase {
 	public function setsDefaultValueInFieldsBasedOnInheritedValue() {
 		$row = array();
 		$className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-		$instance = $this->getMock($className, array('getInheritedPropertyValueByDottedPath'));
+		$instance = $this->getMock($className, array('getInheritedPropertyValueByDottedPath', 'getInheritedConfiguration'));
 		$instance->expects($this->once())->method('getInheritedPropertyValueByDottedPath')
-			->with($row, 'input')->will($this->returnValue('default'));
+			->with(array(), 'input')->will($this->returnValue('default'));
+		$instance->expects($this->once())->method('getInheritedConfiguration')
+			->with($row)->will($this->returnValue(array()));
 		$form = Form::create();
 		$field = $form->createField('Input', 'input');
 		$returnedForm = $this->callInaccessibleMethod($instance, 'setDefaultValuesInFieldsWithInheritedValues', $form, $row);
@@ -318,8 +320,7 @@ class PageProviderTest extends AbstractTestCase {
 	 */
 	public function testGetInheritedPropertyValueByDottedPath(array $input, $path, $expected) {
 		$provider = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getInheritedConfiguration'));
-		$provider->expects($this->once())->method('getInheritedConfiguration')->willReturn($input);
-		$result = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', array(), $path);
+		$result = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', $input, $path);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
moves the getInheritedConfiguration method out of the getInheritedPropertyValueByDottedPath to prevent thousands of unnecessary method calls.

Example with ~15 Fields on one page:

<table>
<tr>
<td>
Before these changes:
</td>
<td>
With this commit:
</td>
</tr>
<tr>
<td>
<img src="http://dl.dropbox.com/u/314491/Screenshots/xi628-zaiuf2.png" style="width: 220px; height: auto;"/>
</td>
<td>
<img src="http://dl.dropbox.com/u/314491/Screenshots/ycwl-we3x_2w.png"  style="width: 220px; height: auto;"/>
</td>
</tr>
</table>