### PR TITLE
[BUGFIX] Show the correct flexform for the selected template

### DIFF
--- a/Classes/Provider/PageLanguageOverlayProvider.php
+++ b/Classes/Provider/PageLanguageOverlayProvider.php
@@ -47,4 +47,13 @@ class PageLanguageOverlayProvider extends PageProvider implements ProviderInterf
 		return $records;
 	}
 
+	/**
+	 * @param array $row
+	 * @return string
+	 */
+	public function getControllerActionReferenceFromRecord(array $row) {
+		$pageRow = $this->recordService->getSingle('pages', '*', $row['pid']);
+		return parent::getControllerActionReferenceFromRecord($pageRow);
+	}
+
 }

--- a/Classes/Provider/SubPageLanguageOverlayProvider.php
+++ b/Classes/Provider/SubPageLanguageOverlayProvider.php
@@ -35,10 +35,11 @@ class SubPageLanguageOverlayProvider extends PageLanguageOverlayProvider impleme
 	 * @return string
 	 */
 	public function getControllerActionReferenceFromRecord(array $row) {
-		if (TRUE === empty($row[self::FIELD_ACTION_SUB])) {
-			$row = $this->pageService->getPageTemplateConfiguration($row['uid']);
+		$pageRow = $this->recordService->getSingle('pages', '*', $row['pid']);
+		if (TRUE === empty($pageRow[self::FIELD_ACTION_SUB])) {
+			$pageRow = $this->pageService->getPageTemplateConfiguration($pageRow['uid']);
 		}
-		return $row[self::FIELD_ACTION_SUB];
+		return $pageRow[self::FIELD_ACTION_SUB];
 	}
 
 	/**
@@ -51,5 +52,4 @@ class SubPageLanguageOverlayProvider extends PageLanguageOverlayProvider impleme
 		$immediateConfiguration = $this->configurationService->convertFlexFormContentToArray($row[$fieldName], $form, NULL, NULL);
 		return $immediateConfiguration;
 	}
-
 }


### PR DESCRIPTION
"Replace deprecated configuration translation" introduced
new translation handling through pages_languages_overlay
but did not take into account to use the page to actually
show the correct flexform, instead the default was always
shown.