### PR TITLE
[TASK] Translate label in custom template selector field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fluidpages Change log
 
+3.5.1 - 2016-03-20
+------------------
+- [#314](https://github.com/FluidTYPO3/fluidpages/pull/314) Perform label translation (required since https://github.com/FluidTYPO3/flux/commit/81bb392f99ab1e30c30303ee5d885a7a44c9ff6f / Flux 7.4.0).
+
 3.5.0 - 2016-03-03
 ------------------
 

--- a/Classes/Backend/PageLayoutSelector.php
+++ b/Classes/Backend/PageLayoutSelector.php
@@ -166,7 +166,8 @@ class PageLayoutSelector {
 			$extension = $form->getExtensionName();
 			$thumbnail = MiscellaneousUtility::getIconForTemplate($form);
 			$template = pathinfo($form->getOption(Form::OPTION_TEMPLATEFILE), PATHINFO_FILENAME);
-			$label = $form->getLabel();
+			$formLabel = $form->getLabel();
+			$label = strpos($formLabel, 'LLL:') === 0 ? LocalizationUtility::translate($formLabel, $extension) : $formLabel;
 			$optionValue = $extension . '->' . lcfirst($template);
 			$selected = ($optionValue == $value ? ' checked="checked"' : '');
 			$option = '<label style="padding: 0.5em; border: 1px solid #CCC; display: inline-block; vertical-align: bottom; margin: 0 1em 1em 0; cursor: pointer; ' . ($selected ? 'background-color: #DDD;' : '')  . '">';


### PR DESCRIPTION
Translates label if label is a reference - required since https://github.com/FluidTYPO3/flux/commit/81bb392f99ab1e30c30303ee5d885a7a44c9ff6f (which assumes consumers of labels do translation or support auto label translation in TYPO3).

Close: #313