### PR TITLE
[BUGFIX] Set full template path on form option templateFile

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -203,7 +203,7 @@ class PageService implements SingletonInterface {
 						);
 						continue;
 					}
-					$form->setOption(Form::OPTION_TEMPLATEFILE, $file);
+					$form->setOption(Form::OPTION_TEMPLATEFILE, $configuredPath . $file);
 					$output[$extensionName][$filename] = $form;
 				}
 			}


### PR DESCRIPTION
This is required for Flux to know the controller which is needed to
assemble the correct path to search for template icons.

closes #309
closes FluidTYPO3/flux#1077