### PR TITLE
Fix inheritance

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -352,7 +352,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface {
 				$provider = $this->pageConfigurationService->resolvePrimaryConfigurationProvider($this->tableName, self::FIELD_NAME_SUB, $branch);
 				$form = $provider->getForm($branch);
 				if (NULL === $form) {
-					break;
+					continue;
 				}
 				$fields = $form->getFields();
 				$values = $provider->getFlexFormValuesSingle($branch);


### PR DESCRIPTION
If a form is not set, the foreach should continue with the following branch in tree and not break.