### PR TITLE
[FEATURE] use contentPid for rendering pages

### DIFF
--- a/Classes/Controller/PageController.php
+++ b/Classes/Controller/PageController.php
@@ -101,7 +101,7 @@ class PageController extends AbstractFluxController implements PageControllerInt
 	 * @return array
 	 */
 	public function getRecord() {
-		return $this->workspacesAwareRecordService->getSingle($this->fluxTableName, '*', $GLOBALS['TSFE']->id);
+		return $this->workspacesAwareRecordService->getSingle($this->fluxTableName, '*', $GLOBALS['TSFE']->contentPid);
 	}
 
 }


### PR DESCRIPTION
The TYPO3 backend functionality "Show Content from Page"
is currently not working, as the field of the TSFE is being ignored.
The TSFE always sets the contentPid right, if the feature is used,
with the pid of the different page or if not, the uid of the current page.