### PR TITLE
[BUGFIX] Implement memoizer for page configuration

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -93,9 +93,13 @@ class PageService implements SingletonInterface
      */
     public function getPageTemplateConfiguration($pageUid)
     {
+        static $cache = [];
         $pageUid = (integer) $pageUid;
         if (1 > $pageUid) {
             return null;
+        }
+        if (array_keys($cache, $pageUid)) {
+            return $cache[$pageUid];
         }
         $page = $this->workspacesAwareRecordService->getSingle('pages', '*', $pageUid);
 
@@ -124,9 +128,9 @@ class PageService implements SingletonInterface
         if (true === empty($resolvedMainTemplateIdentity) && true === empty($resolvedSubTemplateIdentity)) {
             // Neither directly configured "this page" nor inherited "sub" contains a valid value;
             // no configuration was detected at all.
-            return null;
+            return $cache[$pageUid] = null;
         }
-        return [
+        return $cache[$pageUid] = [
             'tx_fed_page_controller_action' => $resolvedMainTemplateIdentity,
             'tx_fed_page_controller_action_sub' => $resolvedSubTemplateIdentity
         ];


### PR DESCRIPTION
This patch limits the number of SQL requests that will be
performed in setups which read page configurations
multiple times.

The performance drain is more expressed on setups where
developers retrieve page configurations, which happens
for example when retrieving page settings in custom menus
rendered with VHS.