### PR TITLE
[TASK] Place a very basic default DS for compat with FormEngine

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,7 +6,7 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup'] = unserialize($_EX
 
 if (FALSE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'])
 	|| TRUE === (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload']) {
-    \FluidTYPO3\Flux\Core::addStaticTypoScript('EXT:fluidpages/Configuration/TypoScript/');
+	\FluidTYPO3\Flux\Core::addStaticTypoScript('EXT:fluidpages/Configuration/TypoScript/');
 }
 
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidpages\Provider\PageProvider');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -31,6 +31,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
 		'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform',
 		'config' => [
 			'type' => 'flex',
+            'ds' => [
+                'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+            ]
 		]
 	],
 	'tx_fed_page_flexform_sub' => [
@@ -38,6 +41,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
 		'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform_sub',
 		'config' => [
 			'type' => 'flex',
+            'ds' => [
+                'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+            ]
 		]
 	],
 ]);


### PR DESCRIPTION
This adds a tiny XML DS for the two Fluidpages fields.
Without them, fluidpages fails since the recent FormEngine
FlexForm DS resolving refactor.