### PR TITLE
[BUGFIX] Switch to templateRootPaths etc. for raw page type

### DIFF
--- a/Classes/Controller/PageController.php
+++ b/Classes/Controller/PageController.php
@@ -104,9 +104,9 @@ class PageController extends AbstractFluxController implements PageControllerInt
         $paths = $this->pageConfigurationService->getViewConfigurationByFileReference($templateFileReference);
         $this->provider->setTemplatePathAndFilename($templatePathAndFilename);
         $this->view->setTemplatePathAndFilename($templatePathAndFilename);
-        $this->view->setTemplateRootPath($paths['templateRootPath']);
-        $this->view->setPartialRootPath($paths['partialRootPath']);
-        $this->view->setLayoutRootPath($paths['layoutRootPath']);
+        $this->view->setTemplateRootPaths((array) $paths['templateRootPaths']);
+        $this->view->setPartialRootPaths((array) $paths['partialRootPaths']);
+        $this->view->setLayoutRootPaths((array) $paths['layoutRootPaths']);
     }
 
     /**


### PR DESCRIPTION
Code was using deprecated templateRootPath etc. singular names.