### PR TITLE
[TASK] Remove usages of deprecated phpunit methods

### DIFF
--- a/Tests/Unit/Backend/BackendLayoutDataProviderTest.php
+++ b/Tests/Unit/Backend/BackendLayoutDataProviderTest.php
@@ -50,16 +50,17 @@ class BackendLayoutDataProviderTest extends UnitTestCase
         $instance = new BackendLayoutDataProvider();
         $pageUid = 1;
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $configurationService */
-        $configurationService = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $configurationService = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('resolvePageProvider', 'debug', 'message')
-        );
+        )->getMock();
         if (null !== $record) {
             $configurationService->expects($this->once())->method('resolvePageProvider')
                 ->with($record)->willReturn($provider);
         }
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $recordService */
-        $recordService = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle'));
+        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
         $recordService->expects($this->once())->method('getSingle')->willReturn($record);
         $instance->injectConfigurationService($configurationService);
         $instance->injectWorkspacesAwareRecordService($recordService);
@@ -74,10 +75,11 @@ class BackendLayoutDataProviderTest extends UnitTestCase
     {
         $form = Form::create(array('id' => 'formId'));
         /** @var Provider|\PHPUnit_Framework_MockObject_MockObject $standardProvider */
-        $standardProvider = $this->getMock(
-            'FluidTYPO3\\Flux\\Provider\\Provider',
+        $standardProvider = $this->getMockBuilder(
+            'FluidTYPO3\\Flux\\Provider\\Provider'
+        )->setMethods(
             array('getControllerActionFromRecord', 'getForm')
-        );
+        )->getMock();
         $standardProvider->expects($this->any())->method('getForm')->willReturn($form);
         $standardProvider->setTemplatePaths(array());
         $actionLessProvider = clone $standardProvider;
@@ -194,10 +196,11 @@ class BackendLayoutDataProviderTest extends UnitTestCase
     public function testGetBackendLayout()
     {
         /** @var BackendLayoutDataProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Backend\\BackendLayoutDataProvider',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Backend\\BackendLayoutDataProvider'
+        )->setMethods(
             array('getBackendLayoutConfiguration', 'ensureDottedKeys', 'encodeTypoScriptArray')
-        );
+        )->getMock();
         $instance->expects($this->at(0))->method('getBackendLayoutConfiguration')->with(1)->willReturn(array('conf'));
         $instance->expects($this->at(1))->method('ensureDottedKeys')->with(array('conf'))->willReturn(array('conf-converted'));
         $instance->expects($this->at(2))->method('encodeTypoScriptArray')->with(array('conf-converted'))->willReturn('config');
@@ -213,10 +216,11 @@ class BackendLayoutDataProviderTest extends UnitTestCase
     public function testAddBackendLayouts()
     {
         /** @var BackendLayoutDataProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Backend\\BackendLayoutDataProvider',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Backend\\BackendLayoutDataProvider'
+        )->setMethods(
             array('getBackendLayoutConfiguration', 'encodeTypoScriptArray')
-        );
+        )->getMock();
         $instance->expects($this->once())->method('getBackendLayoutConfiguration')->with(1)->willReturn(array('conf'));
         $instance->expects($this->once())->method('encodeTypoScriptArray')->with(array('conf'))->willReturn('conf');
         $collection = new BackendLayoutCollection('collection');

--- a/Tests/Unit/Backend/BackendLayoutTest.php
+++ b/Tests/Unit/Backend/BackendLayoutTest.php
@@ -51,17 +51,18 @@ class BackendLayoutTest extends UnitTestCase
         $pageUid = 1;
         $backendLayout = array();
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $configurationService */
-        $configurationService = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $configurationService = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('resolvePrimaryConfigurationProvider', 'debug', 'message')
-        );
+        )->getMock();
         $configurationService->expects($this->exactly($messageCount))->method($messageFunction);
         if (null !== $record) {
             $configurationService->expects($this->once())->method('resolvePrimaryConfigurationProvider')
                 ->with('pages', 'tx_fed_page_flexform', $record)->willReturn($provider);
         }
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $recordService */
-        $recordService = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle'));
+        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
         $recordService->expects($this->once())->method('getSingle')->willReturn($record);
         $instance->injectConfigurationService($configurationService);
         $instance->injectWorkspacesAwareRecordService($recordService);
@@ -76,10 +77,11 @@ class BackendLayoutTest extends UnitTestCase
     {
         $form = Form::create(array('id' => 'formId'));
         /** @var Provider|\PHPUnit_Framework_MockObject_MockObject $standardProvider */
-        $standardProvider = $this->getMock(
-            'FluidTYPO3\\Flux\\Provider\\Provider',
+        $standardProvider = $this->getMockBuilder(
+            'FluidTYPO3\\Flux\\Provider\\Provider'
+        )->setMethods(
             array('getControllerActionFromRecord', 'getForm')
-        );
+        )->getMock();
         $standardProvider->setTemplatePaths(array());
         $standardProvider->expects($this->any())->method('getForm')->willReturn($form);
         $actionLessProvider = clone $standardProvider;
@@ -152,7 +154,7 @@ class BackendLayoutTest extends UnitTestCase
         $id = 1;
         $tca = array('foo' => 'bar');
         /** @var FormEngine $mock */
-        $mock = $this->getMock('TYPO3\CMS\Backend\Form\FormEngine', array('fake'), array(), '', false);
+        $mock = $this->getMockBuilder('TYPO3\CMS\Backend\Form\FormEngine')->setMethods(array('fake'))->disableOriginalConstructor()->getMock();
         $instance = new BackendLayout();
         $instance->postProcessColPosListItemsParsed($id, $tca, $mock);
         $this->assertEquals(1, $id);

--- a/Tests/Unit/Backend/PageLayoutSelectorTest.php
+++ b/Tests/Unit/Backend/PageLayoutSelectorTest.php
@@ -40,9 +40,9 @@ class PageLayoutSelectorTest extends UnitTestCase
     public function testRenderField()
     {
         /** @var PageLayoutSelector $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Backend\\PageLayoutSelector', array('renderInheritanceField', 'renderOptions'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Backend\\PageLayoutSelector')->setMethods(array('renderInheritanceField', 'renderOptions'))->getMock();
         /** @var PageService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\PageService', array('getAvailablePageTemplateFiles'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\PageService')->setMethods(array('getAvailablePageTemplateFiles'))->getMock();
         $service->expects($this->once())->method('getAvailablePageTemplateFiles')->willReturn(array('foo' => array('bar')));
         $instance->injectPageService($service);
         $parameters = array();
@@ -62,7 +62,7 @@ class PageLayoutSelectorTest extends UnitTestCase
     {
         $typoScript = array('plugin.' => array('tx_fluidpages.' => $settings));
         /** @var ConfigurationManager|\PHPUnit_Framework_MockObject_MockObject $configurationManager */
-        $configurationManager = $this->getMock('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager', array('getConfiguration'));
+        $configurationManager = $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager')->setMethods(array('getConfiguration'))->getMock();
         $configurationManager->expects($this->any())->method('getConfiguration')->willReturn($typoScript);
         $instance = new PageLayoutSelector();
         $instance->injectConfigurationManager($configurationManager);
@@ -110,7 +110,7 @@ class PageLayoutSelectorTest extends UnitTestCase
      */
     public function testRenderOptions($extension, $expectedTitle)
     {
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Backend\\PageLayoutSelector', array('renderOption'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Backend\\PageLayoutSelector')->setMethods(array('renderOption'))->getMock();
         $instance->expects($this->any())->method('renderOption')->willReturn('');
         $forms = array(
             Form::create(array('extensionName' => $extension))
@@ -135,7 +135,7 @@ class PageLayoutSelectorTest extends UnitTestCase
      */
     public function testRenderOption()
     {
-        $correctForm = $this->getMock('FluidTYPO3\\Flux\\Form', array('getLabel'));
+        $correctForm = $this->getMockBuilder('FluidTYPO3\\Flux\\Form')->setMethods(array('getLabel'))->getMock();
         $correctForm->expects($this->once())->method('getLabel')->willReturn('label');
         $instance = new PageLayoutSelector();
         $result = $this->callInaccessibleMethod($instance, 'renderOption', $correctForm, array());

--- a/Tests/Unit/Backend/TemplateFileLayoutSelectorTest.php
+++ b/Tests/Unit/Backend/TemplateFileLayoutSelectorTest.php
@@ -40,7 +40,7 @@ class TemplateFileLayoutSelectorTest extends UnitTestCase
         $instance = new TemplateFileLayoutSelector();
         $parent = '';
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService', array('getViewConfigurationByFileReference'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService')->setMethods(array('getViewConfigurationByFileReference'))->getMock();
         $service->expects($this->once())->method('getViewConfigurationByFileReference')->willReturn(array(
             'layoutRootPaths' => array($layoutRootPath)
         ));

--- a/Tests/Unit/Controller/PageControllerTest.php
+++ b/Tests/Unit/Controller/PageControllerTest.php
@@ -44,9 +44,9 @@ class PageControllerTest extends UnitTestCase
     public function testGetRecordDelegatesToRecordService()
     {
         /** @var PageController $subject */
-        $subject = $this->getMock('FluidTYPO3\\Fluidpages\\Controller\\PageController', array('dummy'));
+        $subject = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Controller\\PageController')->setMethods(array('dummy'))->getMock();
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $mockService */
-        $mockService = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle'));
+        $mockService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
         $mockService->expects($this->once())->method('getSingle');
         $subject->injectWorkspacesAwareRecordService($mockService);
         $subject->getRecord();
@@ -63,42 +63,45 @@ class PageControllerTest extends UnitTestCase
             )
         );
         /** @var ConfigurationManager|\PHPUnit_Framework_MockObject_MockObject $configurationManager */
-        $configurationManager = $this->getMock(
-            'TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager',
+        $configurationManager = $this->getMockBuilder(
+            'TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager'
+        )->setMethods(
             array('getContentObject', 'getConfiguration')
-        );
+        )->getMock();
         $contentObject = new \stdClass();
         $configurationManager->expects($this->once())->method('getContentObject')->willReturn($contentObject);
         $configurationManager->expects($this->once())->method('getConfiguration')->willReturn(array('foo' => 'bar'));
         $instance->expects($this->once())->method('getRecord')->willReturn(array('uid' => 0));
         $GLOBALS['TSFE'] = (object) array('page' => 'page', 'fe_user' => (object) array('user' => 'user'));
         /** @var StandaloneView $view */
-        $view = $this->getMock('FluidTYPO3\\Flux\\View\\ExposedTemplateView', array('assign', 'renderStandaloneSection'));
+        $view = $this->getMockBuilder('FluidTYPO3\\Flux\\View\\ExposedTemplateView')->setMethods(array('assign', 'renderStandaloneSection'))->getMock();
         $instance->injectConfigurationManager($configurationManager);
-        $instance->_set('response', $this->getMock('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Response'));
-        $instance->_set('provider', $this->getMock('FluidTYPO3\\Flux\\Provider\\ProviderInterface'));
+        $instance->_set('response', $this->getMockBuilder('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Response')->getMock());
+        $instance->_set('provider', $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\ProviderInterface')->getMock());
         $instance->initializeView($view);
     }
 
     public function testInitializeProvider()
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $pageConfigurationService */
-        $pageConfigurationService = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $pageConfigurationService = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array(
                 'resolvePrimaryConfigurationProvider',
             )
-        );
+        )->getMock();
         /** @var PageService $pageService */
-        $pageService = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\PageService',
+        $pageService = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\PageService'
+        )->setMethods(
             array(
                 'getPageTemplateConfiguration'
             )
-        );
+        )->getMock();
         $pageConfigurationService->expects($this->once())->method('resolvePrimaryConfigurationProvider');
         /** @var PageController|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Controller\\PageController', array('getRecord'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Controller\\PageController')->setMethods(array('getRecord'))->getMock();
         $instance->expects($this->once())->method('getRecord')->willReturn(array());
         $instance->injectpageConfigurationService($pageConfigurationService);
         $instance->injectPageService($pageService);
@@ -109,15 +112,16 @@ class PageControllerTest extends UnitTestCase
     {
         $instance = new DummyPageController();
         /** @var ExposedTemplateView $view */
-        $view = $this->getMock('FluidTYPO3\\Flux\\View\\ExposedTemplateView', array('assign'));
+        $view = $this->getMockBuilder('FluidTYPO3\\Flux\\View\\ExposedTemplateView')->setMethods(array('assign'))->getMock();
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $pageConfigurationService */
-        $pageConfigurationService = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $pageConfigurationService = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array(
                 'convertFileReferenceToTemplatePathAndFilename',
                 'getViewConfigurationByFileReference',
             )
-        );
+        )->getMock();
         $pageConfigurationService->expects($this->once())->method('convertFileReferenceToTemplatePathAndFilename')->willReturn('test');
         $pageConfigurationService->expects($this->once())->method('getViewConfigurationByFileReference')->willReturn(array());
         $instance->injectpageConfigurationService($pageConfigurationService);

--- a/Tests/Unit/Provider/PageProviderTest.php
+++ b/Tests/Unit/Provider/PageProviderTest.php
@@ -43,7 +43,7 @@ class PageProviderTest extends AbstractTestCase
     public function testGetExtensionKey()
     {
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getControllerExtensionKeyFromRecord'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getControllerExtensionKeyFromRecord'))->getMock();
         $instance->expects($this->once())->method('getControllerExtensionKeyFromRecord')->willReturn('fluidpages');
         $result = $instance->getExtensionKey(array());
         $this->assertEquals('fluidpages', $result);
@@ -52,7 +52,7 @@ class PageProviderTest extends AbstractTestCase
     public function testGetExtensionKeyWithoutSelection()
     {
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getControllerExtensionKeyFromRecord'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getControllerExtensionKeyFromRecord'))->getMock();
         $instance->expects($this->once())->method('getControllerExtensionKeyFromRecord')->willReturn(null);
         $result = $instance->getExtensionKey(array());
         $this->assertEquals('fluidpages', $result);
@@ -64,7 +64,7 @@ class PageProviderTest extends AbstractTestCase
         $fieldName = 'tx_fed_page_controller_action';
         $dataFieldName = 'tx_fed_page_flexform';
         /** @var PageService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\PageService', array('getPageTemplateConfiguration'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\PageService')->setMethods(array('getPageTemplateConfiguration'))->getMock();
         $instance = new PageProvider();
         $instance->setTemplatePaths(array('templateRootPaths' => array('EXT:fluidpages/Tests/Fixtures/Templates/')));
         $instance->injectPageService($service);
@@ -82,7 +82,7 @@ class PageProviderTest extends AbstractTestCase
         /** @var Form $form */
         $form = Form::create();
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('setDefaultValuesInFieldsWithInheritedValues'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('setDefaultValuesInFieldsWithInheritedValues'))->getMock();
         $instance->injectPageService(new PageService());
         $instance->expects($this->once())->method('setDefaultValuesInFieldsWithInheritedValues')->willReturn($form);
         $instance->setForm($form);
@@ -92,7 +92,7 @@ class PageProviderTest extends AbstractTestCase
     public function testGetControllerExtensionKeyFromRecordReturnsPresetKeyOnUnrecognisedAction()
     {
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getControllerActionReferenceFromRecord'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getControllerActionReferenceFromRecord'))->getMock();
         $instance->expects($this->once())->method('getControllerActionReferenceFromRecord')->willReturn('invalid');
         $instance->setExtensionKey('fallback');
         $result = $instance->getControllerExtensionKeyFromRecord(array());
@@ -107,7 +107,7 @@ class PageProviderTest extends AbstractTestCase
     public function testGetInheritanceTree(array $input, array $expected)
     {
         $record = array('uid' => 1);
-        $instance = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('loadRecordTreeFromDatabase'));
+        $instance = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('loadRecordTreeFromDatabase'))->getMock();
         $instance->expects($this->once())->method('loadRecordTreeFromDatabase')->with($record)->willReturn($input);
         $result = $this->callInaccessibleMethod($instance, 'getInheritanceTree', $record);
         $this->assertEquals($expected, $result);
@@ -143,12 +143,12 @@ class PageProviderTest extends AbstractTestCase
         $instance = new PageProvider();
         if (PageControllerInterface::DOKTYPE_RAW !== $record['doktype'] && true === empty($record[$fieldName])) {
             /** @var PageService $service */
-            $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\PageService', array('getPageTemplateConfiguration'));
+            $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\PageService')->setMethods(array('getPageTemplateConfiguration'))->getMock();
             $instance->injectPageService($service);
         }
         if (true === $expectsMessage) {
             /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $configurationService */
-            $configurationService = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService', array('message'));
+            $configurationService = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService')->setMethods(array('message'))->getMock();
             $configurationService->expects($this->once())->method('message');
             $instance->injectPageConfigurationService($configurationService);
         }
@@ -187,9 +187,9 @@ class PageProviderTest extends AbstractTestCase
         $dummyProvider1->setForm($form);
         $dummyProvider1->setFlexFormValues(array('foo' => 'bar'));
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getInheritanceTree', 'unsetInheritedValues', 'getForm'));
+        $provider = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getInheritanceTree', 'unsetInheritedValues', 'getForm'))->getMock();
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $mockConfigurationService */
-        $mockConfigurationService = $this->getMock('FluidTYPO3\Fluidpages\Service\ConfigurationService', array('resolvePrimaryConfigurationProvider'));
+        $mockConfigurationService = $this->getMockBuilder('FluidTYPO3\Fluidpages\Service\ConfigurationService')->setMethods(array('resolvePrimaryConfigurationProvider'))->getMock();
         $mockConfigurationService->expects($this->at(0))->method('resolvePrimaryConfigurationProvider')->willReturn($dummyProvider1);
         $mockConfigurationService->expects($this->at(1))->method('resolvePrimaryConfigurationProvider')->willReturn($dummyProvider2);
         $provider->expects($this->once())->method('getInheritanceTree')->will($this->returnValue($tree));
@@ -226,9 +226,9 @@ class PageProviderTest extends AbstractTestCase
         $form2 = Form::create();
         $dummyProvider2->setForm($form2);
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getInheritanceTree', 'unsetInheritedValues', 'getForm'));
+        $provider = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getInheritanceTree', 'unsetInheritedValues', 'getForm'))->getMock();
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $mockConfigurationService */
-        $mockConfigurationService = $this->getMock('FluidTYPO3\Fluidpages\Service\ConfigurationService', array('resolvePrimaryConfigurationProvider'));
+        $mockConfigurationService = $this->getMockBuilder('FluidTYPO3\Fluidpages\Service\ConfigurationService')->setMethods(array('resolvePrimaryConfigurationProvider'))->getMock();
         $mockConfigurationService->expects($this->at(0))->method('resolvePrimaryConfigurationProvider')->willReturn($dummyProvider1);
         $mockConfigurationService->expects($this->at(1))->method('resolvePrimaryConfigurationProvider')->willReturn($dummyProvider2);
         $provider->expects($this->once())->method('getInheritanceTree')->will($this->returnValue($tree));
@@ -246,10 +246,11 @@ class PageProviderTest extends AbstractTestCase
     public function canLoadRecordTreeFromDatabase()
     {
         $record = $this->getBasicRecord();
-        $provider = $this->getMock(
-            str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)),
+        $provider = $this->getMockBuilder(
+            str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4))
+        )->setMethods(
             array('loadRecordFromDatabase', 'getParentFieldName', 'getParentFieldValue')
-        );
+        )->getMock();
         $provider->expects($this->exactly(2))->method('getParentFieldName')->will($this->returnValue('somefield'));
         $provider->expects($this->exactly(1))->method('getParentFieldValue')->will($this->returnValue(1));
         $provider->expects($this->exactly(1))->method('loadRecordFromDatabase')->will($this->returnValue($record));
@@ -265,7 +266,7 @@ class PageProviderTest extends AbstractTestCase
     {
         $row = array();
         $className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-        $instance = $this->getMock($className, array('getInheritedPropertyValueByDottedPath', 'getInheritedConfiguration'));
+        $instance = $this->getMockBuilder($className)->setMethods(array('getInheritedPropertyValueByDottedPath', 'getInheritedConfiguration'))->getMock();
         $instance->expects($this->once())->method('getInheritedPropertyValueByDottedPath')
             ->with(array(), 'input')->will($this->returnValue('default'));
         $instance->expects($this->once())->method('getInheritedConfiguration')
@@ -323,7 +324,7 @@ class PageProviderTest extends AbstractTestCase
         $rowWithPid = $row;
         $rowWithPid['pid'] = 1;
         $className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-        $instance = $this->getMock($className, array('getParentFieldName', 'getTableName', 'loadRecordFromDatabase'));
+        $instance = $this->getMockBuilder($className)->setMethods(array('getParentFieldName', 'getTableName', 'loadRecordFromDatabase'))->getMock();
         $instance->expects($this->once())->method('loadRecordFromDatabase')->with($row['uid'])->will($this->returnValue($rowWithPid));
         $instance->expects($this->once())->method('getParentFieldName')->with($row)->will($this->returnValue('pid'));
         $result = $this->callInaccessibleMethod($instance, 'getParentFieldValue', $row);
@@ -338,7 +339,7 @@ class PageProviderTest extends AbstractTestCase
      */
     public function testGetInheritedPropertyValueByDottedPath(array $input, $path, $expected)
     {
-        $provider = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getInheritedConfiguration'));
+        $provider = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getInheritedConfiguration'))->getMock();
         $result = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', $input, $path);
         $this->assertEquals($expected, $result);
     }
@@ -373,7 +374,7 @@ class PageProviderTest extends AbstractTestCase
     public function canPostProcessRecord()
     {
         /** @var PageProvider|\PHPUnit_Framework_MockObject_MockObject $provider */
-        $provider = $this->getMock('FluidTYPO3\\Fluidpages\\Provider\\PageProvider', array('getForm', 'getInheritedPropertyValueByDottedPath'));
+        $provider = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Provider\\PageProvider')->setMethods(array('getForm', 'getInheritedPropertyValueByDottedPath'))->getMock();
         $form = Form::create();
         $form->createField('Input', 'settings.input')->setInherit(true);
         $record = $this->getBasicRecord();
@@ -403,11 +404,11 @@ class PageProviderTest extends AbstractTestCase
         $provider->expects($this->once())->method('getInheritedPropertyValueByDottedPath')
             ->with($parentInstance->datamap[$tableName][$id], 'settings.input')->willReturn('test');
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $recordService */
-        $recordService = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle', 'update'));
+        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle', 'update'))->getMock();
         $recordService->expects($this->atLeastOnce())->method('getSingle')->willReturn($parentInstance->datamap[$tableName][$id]);
         $recordService->expects($this->once())->method('update');
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $configurationService */
-        $configurationService = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService', array('message'));
+        $configurationService = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService')->setMethods(array('message'))->getMock();
         $configurationService->expects($this->any())->method('message');
         $provider->injectRecordService($recordService);
         $provider->injectPageConfigurationService($configurationService);

--- a/Tests/Unit/Provider/SubPageProviderTest.php
+++ b/Tests/Unit/Provider/SubPageProviderTest.php
@@ -34,12 +34,12 @@ class SubPageProviderTest extends AbstractTestCase
         $instance = new SubPageProvider();
         if (PageControllerInterface::DOKTYPE_RAW !== $record['doktype']) {
             /** @var PageService $service */
-            $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\PageService', array('getPageTemplateConfiguration'));
+            $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\PageService')->setMethods(array('getPageTemplateConfiguration'))->getMock();
             $instance->injectPageService($service);
         }
         if (true === $expectsMessage) {
             /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $configurationService */
-            $configurationService = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService', array('message'));
+            $configurationService = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\ConfigurationService')->setMethods(array('message'))->getMock();
             $configurationService->expects($this->once())->method('message');
             $instance->injectPageConfigurationService($configurationService);
         }
@@ -67,7 +67,7 @@ class SubPageProviderTest extends AbstractTestCase
         $dataFieldName = 'tx_fed_page_flexform_sub';
         $fieldName = 'tx_fed_page_controller_action_sub';
         /** @var PageService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Fluidpages\\Service\\PageService', array('getPageTemplateConfiguration'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Fluidpages\\Service\\PageService')->setMethods(array('getPageTemplateConfiguration'))->getMock();
         $instance = new SubPageProvider();
         $instance->setTemplatePaths(array('templateRootPaths' => array('EXT:fluidpages/Tests/Fixtures/Templates/')));
         $instance->injectPageService($service);

--- a/Tests/Unit/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ConfigurationServiceTest.php
@@ -42,10 +42,11 @@ class ConfigurationServiceTest extends UnitTestCase
         $instance = new ConfigurationService();
         if (null !== $resourceFactoryOutput) {
             /** @var ResourceFactory|\PHPUnit_Framework_MockObject_MockObject $resourceFactory */
-            $resourceFactory = $this->getMock(
-                'TYPO3\\CMS\\Core\\Resource\\ResourceFactory',
+            $resourceFactory = $this->getMockBuilder(
+                'TYPO3\\CMS\\Core\\Resource\\ResourceFactory'
+            )->setMethods(
                 array('getFileObjectFromCombinedIdentifier')
-            );
+            )->getMock();
             $resourceFactory->expects($this->once())->method('getFileObjectFromCombinedIdentifier')
                 ->with($reference)->willReturn($resourceFactoryOutput);
             $instance->injectResourceFactory($resourceFactory);
@@ -75,10 +76,11 @@ class ConfigurationServiceTest extends UnitTestCase
     public function testGetViewConfigurationByFileReference($reference, $expectedParameter)
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('getViewConfigurationForExtensionName')
-        );
+        )->getMock();
         $instance->expects($this->once())->method('getViewConfigurationForExtensionName')
             ->with($expectedParameter)->willReturn($expectedParameter);
         $result = $instance->getViewConfigurationByFileReference($reference);
@@ -105,10 +107,11 @@ class ConfigurationServiceTest extends UnitTestCase
     public function testGetPageConfigurationReturnsEmptyArrayAndDispatchesMessageOnInvalidInput($input)
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('message')
-        );
+        )->getMock();
         $instance->expects($this->once())->method('message');
         $result = $instance->getPageConfiguration($input);
         $this->assertEquals(array(), $result);
@@ -132,10 +135,11 @@ class ConfigurationServiceTest extends UnitTestCase
     public function testGetPageConfigurationCallsGetViewConfigurationForExtensionName()
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('getViewConfigurationForExtensionName')
-        );
+        )->getMock();
         $instance->expects($this->once())->method('getViewConfigurationForExtensionName')->with('foobar')->willReturn(array());
         $result = $instance->getPageConfiguration('foobar');
         $this->assertEquals(array(), $result);
@@ -147,10 +151,11 @@ class ConfigurationServiceTest extends UnitTestCase
     public function testGetPageConfigurationWithoutExtensionNameReadsRegisteredProviders()
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $instance */
-        $instance = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $instance = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('getViewConfigurationForExtensionName')
-        );
+        )->getMock();
         Core::registerProviderExtensionKey('foo', 'Page');
         Core::registerProviderExtensionKey('bar', 'Page');
         $instance->expects($this->exactly(2))->method('getViewConfigurationForExtensionName');

--- a/Tests/Unit/Service/PageServiceTest.php
+++ b/Tests/Unit/Service/PageServiceTest.php
@@ -53,7 +53,7 @@ class PageServiceTest extends UnitTestCase
     public function testGetPageTemplateConfiguration(array $records, $expected)
     {
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
         foreach ($records as $index => $record) {
             $service->expects($this->at($index))->method('getSingle')->willReturn($record);
         }
@@ -86,7 +86,7 @@ class PageServiceTest extends UnitTestCase
         $record1 = array('pid' => 2, 'uid' => 1);
         $record2 = array('pid' => 0, 'uid' => 3, 'tx_fed_page_flexform' => 'test');
         /** @var WorkspacesAwareRecordService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('getSingle'));
+        $service = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
         $service->expects($this->at(0))->method('getSingle')->with('pages', '*', 1)->willReturn($record1);
         $service->expects($this->at(1))->method('getSingle')->with('pages', '*', 2)->willReturn($record2);
         $instance = new PageService();
@@ -103,10 +103,11 @@ class PageServiceTest extends UnitTestCase
     public function testGetAvailablePageTemplateFiles($typoScript, $expected)
     {
         /** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $service */
-        $service = $this->getMock(
-            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService',
+        $service = $this->getMockBuilder(
+            'FluidTYPO3\\Fluidpages\\Service\\ConfigurationService'
+        )->setMethods(
             array('getPageConfiguration', 'message', 'getFormFromTemplateFile')
-        );
+        )->getMock();
         $service->expects($this->any())->method('getFormFromTemplateFile')->willReturn(Form::create());
         $service->expects($this->once())->method('getPageConfiguration')->willReturn($typoScript);
         $service->expects($this->any())->method('message');


### PR DESCRIPTION
Last remnants of mess (outside of formalities like `::class` and shorthand array in tests classes).