### PR TITLE
[BUGFIX] Do not try to create option icon if template has no icon

### DIFF
--- a/Classes/Backend/PageLayoutDataProvider.php
+++ b/Classes/Backend/PageLayoutDataProvider.php
@@ -161,8 +161,10 @@ class PageLayoutDataProvider
         try {
             $extension = $form->getExtensionName();
             $thumbnail = MiscellaneousUtility::getIconForTemplate($form);
-            $thumbnail = ltrim($thumbnail, '/');
-            $thumbnail = MiscellaneousUtility::createIcon(GeneralUtility::getFileAbsFileName($thumbnail), 64, 64);
+            if (NULL !== $thumbnail) {
+                $thumbnail = ltrim($thumbnail, '/');
+                $thumbnail = MiscellaneousUtility::createIcon(GeneralUtility::getFileAbsFileName($thumbnail), 64, 64);
+            }
             $template = pathinfo($form->getOption(Form::OPTION_TEMPLATEFILE), PATHINFO_FILENAME);
             $formLabel = $form->getLabel();
             if (strpos($formLabel, 'LLL:') === 0) {

--- a/Tests/Unit/Backend/PageLayoutDataProviderTest.php
+++ b/Tests/Unit/Backend/PageLayoutDataProviderTest.php
@@ -63,27 +63,27 @@ class PageLayoutDataProviderTest extends AbstractTestCase
             [
                 [],
                 [],
-                [['Fluid Pages Engine', '--div--'], [null, '->', 'icon-d41d8cd98f00b204e9800998ecf8427e']]
+                [['Fluid Pages Engine', '--div--'], [null, '->', null]]
             ],
             [
                 [],
                 [['foo', 'bar', 'baz']],
-                [['foo', 'bar', 'baz'], ['Fluid Pages Engine', '--div--'], [null, '->', 'icon-d41d8cd98f00b204e9800998ecf8427e']]
+                [['foo', 'bar', 'baz'], ['Fluid Pages Engine', '--div--'], [null, '->', null]]
             ],
             [
                 ['field' => 'tx_fed_page_controller_action_sub', 'row' => ['pid' => 1]],
                 [['foo', 'bar', 'baz']],
-                [['foo', 'bar', 'baz'], ['Parent decides', '', 'actions-move-down'], ['Fluid Pages Engine', '--div--'], [null, '->', 'icon-d41d8cd98f00b204e9800998ecf8427e']]
+                [['foo', 'bar', 'baz'], ['Parent decides', '', 'actions-move-down'], ['Fluid Pages Engine', '--div--'], [null, '->', null]]
             ],
             [
                 ['field' => 'tx_fed_page_controller_action_sub', 'row' => ['pid' => 1, 'is_siteroot' => false]],
                 [['foo', 'bar', 'baz']],
-                [['foo', 'bar', 'baz'], ['Parent decides', '', 'actions-move-down'], ['Fluid Pages Engine', '--div--'], [null, '->', 'icon-d41d8cd98f00b204e9800998ecf8427e']]
+                [['foo', 'bar', 'baz'], ['Parent decides', '', 'actions-move-down'], ['Fluid Pages Engine', '--div--'], [null, '->', null]]
             ],
             [
                 ['field' => 'tx_fed_page_controller_action', 'row' => ['pid' => 0, 'is_siteroot' => true]],
                 [['foo', 'bar', 'baz']],
-                [['foo', 'bar', 'baz'], ['Fluid Pages Engine', '--div--'], [null, '->', 'icon-d41d8cd98f00b204e9800998ecf8427e']]
+                [['foo', 'bar', 'baz'], ['Fluid Pages Engine', '--div--'], [null, '->', null]]
             ],
 
         ];


### PR DESCRIPTION
MiscellaneousUtility::getIconForTemplate can return NULL if no icon exists for the
specified template. Using MiscellaneousUtility::createIcon on this erroneous path
will lead to a TYPO3 exception on rendering the edit form (at least in v8.6.0).