### PR TITLE
[BUGFIX] omit form caching if form === null

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -182,11 +182,11 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         $form = parent::getForm($row);
         if (null !== $form) {
             $form = $this->setDefaultValuesInFieldsWithInheritedValues($form, $row);
-        }
-        if ($form->getOption(Form::OPTION_STATIC)) {
-            $persistentCache->set($cacheId, $form);
-        } else {
-            $runtimeCache->set($cacheId, $form);
+            if ($form->getOption(Form::OPTION_STATIC)) {
+                $persistentCache->set($cacheId, $form);
+            } else {
+                $runtimeCache->set($cacheId, $form);
+            }
         }
         return $form;
     }

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -184,10 +184,9 @@ class PageProvider extends AbstractProvider implements ProviderInterface
             $form = $this->setDefaultValuesInFieldsWithInheritedValues($form, $row);
             if ($form->getOption(Form::OPTION_STATIC)) {
                 $persistentCache->set($cacheId, $form);
-            } else {
-                $runtimeCache->set($cacheId, $form);
             }
         }
+        $runtimeCache->set($cacheId, $form);
         return $form;
     }
 


### PR DESCRIPTION
With current development branch, if you try to create a new page via the context menu in page tree, you get following error:

> Call to a member function getOption() on null 
>
> Error thrown in file
> typo3conf/ext/fluidpages/Classes/Provider/PageProvider.php in line 186.

This new caching was introduced very recently with d4ce98a72f3eef6f1cb946ac99917185a5ff82f5