### PR TITLE
[BUGFIX] moved addStaticFile() for non-autoload mode into TCA/Overrides/sys_template.php

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,8 @@
+<?php
+defined ('TYPO3_MODE') or die ('Access denied.');
+
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['fluidpages']);
+
+if (!($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'] ?? true)) {
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('fluidpages', 'Configuration/TypoScript', 'Fluidpages PAGE rendering');
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,7 +25,7 @@ if (!defined ('TYPO3_MODE')) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['BackendLayoutDataProvider']['fluidpages'] = \FluidTYPO3\Fluidpages\Backend\BackendLayoutDataProvider::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook'][] = \FluidTYPO3\Fluidpages\Hooks\PagePreviewRenderer::class . '->render';
 
-    if (($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'] ?? true)) {
+    if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'] ?? true) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptConstants(file_get_contents(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('fluidpages', 'Configuration/TypoScript/constants.txt')));
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(file_get_contents(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('fluidpages', 'Configuration/TypoScript/setup.txt')));
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,9 +25,7 @@ if (!defined ('TYPO3_MODE')) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['BackendLayoutDataProvider']['fluidpages'] = \FluidTYPO3\Fluidpages\Backend\BackendLayoutDataProvider::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook'][] = \FluidTYPO3\Fluidpages\Hooks\PagePreviewRenderer::class . '->render';
 
-    if (!($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'] ?? true)) {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Fluidpages PAGE rendering');
-    } else {
+    if (($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']['autoload'] ?? true)) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptConstants(file_get_contents(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('fluidpages', 'Configuration/TypoScript/constants.txt')));
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(file_get_contents(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('fluidpages', 'Configuration/TypoScript/setup.txt')));
     }


### PR DESCRIPTION
When called in ext_localconf.php the TCA is not loaded and thus the template not available.

The method documentation in Typo3 8.7 states:
- addStaticFile: FOR USE IN Configuration/TCA/Overrides/sys_template.php
- addTypoScriptConstants, addTypoScriptSetup: FOR USE IN ext_localconf.php FILES