### PR TITLE
[BUGFIX] Page and SubPageLanguageOverlay Provider bug and missing TCA…

### DIFF
--- a/Classes/Provider/PageLanguageOverlayProvider.php
+++ b/Classes/Provider/PageLanguageOverlayProvider.php
@@ -53,7 +53,16 @@ class PageLanguageOverlayProvider extends PageProvider implements ProviderInterf
      */
     public function getControllerActionReferenceFromRecord(array $row)
     {
-        $pageRow = (array) $this->recordService->getSingle('pages', '*', $row['pid']);
+
+        $pid = $row['pid'] ?? $row[0]['pid'];
+
+        if(empty($pid) && isset($row['doktype'])) {
+            return 'render';
+        } elseif(empty($row)) {
+            return 'error';
+        }
+
+        $pageRow = (array) $this->recordService->getSingle('pages', '*', $pid);
         return parent::getControllerActionReferenceFromRecord($pageRow);
     }
 }

--- a/Classes/Provider/SubPageLanguageOverlayProvider.php
+++ b/Classes/Provider/SubPageLanguageOverlayProvider.php
@@ -36,7 +36,16 @@ class SubPageLanguageOverlayProvider extends PageLanguageOverlayProvider impleme
      */
     public function getControllerActionReferenceFromRecord(array $row)
     {
-        $pageRow = $this->recordService->getSingle('pages', '*', $row['pid']);
+
+        $pid = $row['pid'] ?? $row[0]['pid'];
+
+        if(empty($pid) && isset($row['doktype'])) {
+            return 'render';
+        } elseif(empty($row)) {
+            return 'error';
+        }
+
+        $pageRow = $this->recordService->getSingle('pages', '*', $pid);
         if (true === empty($pageRow[self::FIELD_ACTION_SUB])) {
             $pageRow = $this->pageService->getPageTemplateConfiguration($pageRow['uid']);
         }

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -13,6 +13,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
             'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform',
             'config' => [
                 'type' => 'flex',
+                'ds' => [
+                    'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+                ]
             ]
         ],
         'tx_fed_page_flexform_sub' => [
@@ -20,6 +23,9 @@ if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidpages']['setup']
             'label' => 'LLL:EXT:fluidpages/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_flexform_sub',
             'config' => [
                 'type' => 'flex',
+                'ds' => [
+                    'default' => '<T3DataStructure><ROOT><el></el></ROOT></T3DataStructure>'
+                ]
             ]
         ],
     ]);


### PR DESCRIPTION
… override conf for "flex" field

When "pagesLanguageConfigurationOverlay" is set to 1, opening existing page language overlay record throws an error for "TCA misconfiguration in table "pages_language_overlay" field "tx_fed_page_flexform" config section".
After adding a default ds template new error is thrown after missing template for "SubPageLanguageOverlay->default" or "PageLanguageOverlay->default" depending on your actions if you add new or edit existing page language overlay record.