### PR TITLE
[BUGFIX] Assign partial and layout root paths, allowing usage in form configuration

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -211,6 +211,9 @@ class PageService implements SingletonInterface
                 }
 
                 $view->setTemplatePathAndFilename($file);
+                $view->setPartialRootPaths($templatePaths->getPartialRootPaths());
+                $view->setLayoutRootPaths($templatePaths->getLayoutRootPaths());
+
                 try {
                     $view->renderSection('Configuration');
                     $form = $view->getRenderingContext()->getViewHelperVariableContainer()->get(FormViewHelper::class, 'form');

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "The fluidpages package from FluidTYPO3",
   "require": {
     "fluidtypo3/flux": "^7.3|^8.0|dev-development",
-    "typo3/cms": "^7.6|^8.4",
+    "typo3/cms": "^7.6|^8.7",
     "php": ">=7.0.0"
   },
   "type": "typo3-cms-extension",


### PR DESCRIPTION
Fixes issue #375, where the Page Layout dropdown was empty due to the configuration section failing to render.