### PR TITLE
[BUGFIX] Avoid root page query in getPageTemplateConfiguration

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -116,6 +116,9 @@ class PageService implements SingletonInterface
             'tx_fed_page_controller_action,' . $fieldList,
             $pageUid
         );
+        if (null === $page) {
+            return null;
+        }
 
         // Initialize with possibly-empty values and loop root line
         // to fill values as they are detected.
@@ -137,6 +140,10 @@ class PageService implements SingletonInterface
             // Note: 't3ver_oid' is analysed in order to make versioned records inherit the original record's
             // configuration as an emulated first parent page.
             $resolveParentPageUid = (integer) (0 > $page['pid'] ? $page['t3ver_oid'] : $page['pid']);
+            // Avoid useless SQL query if uid is 0, because uids in the database start from 1.
+            if (0 === $resolveParentPageUid) {
+                break;
+            }
             $page = $this->workspacesAwareRecordService->getSingle(
                 'pages',
                 $fieldList,

--- a/Tests/Unit/Service/PageServiceTest.php
+++ b/Tests/Unit/Service/PageServiceTest.php
@@ -62,7 +62,7 @@ class PageServiceTest extends AbstractTestCase
         }
         $instance = new PageService();
         $instance->injectWorkspacesAwareRecordService($service);
-        $result = $instance->getPageTemplateConfiguration(1);
+        $result = $instance->getPageTemplateConfiguration(2);
         $this->assertEquals($expected, $result);
     }
 
@@ -71,13 +71,17 @@ class PageServiceTest extends AbstractTestCase
      */
     public function getPageTemplateConfigurationTestValues()
     {
+        $u = 'uid';
+        $p = 'pid';
+        $o = 't3ver_oid';
         $m = 'tx_fed_page_controller_action';
         $s = 'tx_fed_page_controller_action_sub';
         return array(
-            array(array(array()), null),
-            array(array(array($m => '', $s => '')), null),
-            array(array(array($m => 'test1->test1', $s => 'test2->test2')), array($m => 'test1->test1', $s => 'test2->test2')),
-            array(array(array($m => ''), array($s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2'))
+            array(array(null), null),
+            array(array(array($u => 2, $p => 0, $o => 0, $m => '', $s => '')), null),
+            array(array(array($u => 2, $p => 0, $o => 0, $m => 'test1->test1', $s => 'test2->test2')), array($m => 'test1->test1', $s => 'test2->test2')),
+            array(array(array($u => 2, $p => 1, $o => 0, $m => ''), array($u => 1, $p => 0, $o => 0, $s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2')),
+            array(array(array($u => 2, $p => -1, $o => 1, $m => ''), array($u => 1, $p => 0, $o => 0, $s => 'test2->test2')), array($m => 'test2->test2', $s => 'test2->test2'))
         );
     }
 


### PR DESCRIPTION
This fix aborts the loop in `PageService->getPageTemplateConfiguration` early if the uid to fetch from the database becomes zero.

Database uids are guaranteed to start from one because uid 0 is reserved for the virtual page root.

This PR started out as a fix for #390 which has been addressed at the root in https://github.com/FluidTYPO3/flux/pull/1654, however I still consider it useful since it avoids a redundant database query.