### PR TITLE
[BUGFIX] Fix PageProvider->getControllerActionFromRecord fallback

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -187,7 +187,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         if (PageControllerInterface::DOKTYPE_RAW === (integer) $row['doktype']) {
             return 'raw';
         }
-        $action = $this->getControllerActionReferenceFromRecord($row) ?? 'default';
+        $action = $this->getControllerActionReferenceFromRecord($row) ?: 'default';
         $parts = explode('->', $action);
         $controllerActionName = end($parts);
         $controllerActionName{0} = strtolower($controllerActionName{0});


### PR DESCRIPTION
This fixes an exception `ucfirst() expects parameter 1 to be string, array given` in the backend when editing a page and no subtemplate can be found up to the root level.

This fix is required to recover from the issue described in #390 without updating the database by hand.